### PR TITLE
Modify time shift

### DIFF
--- a/src/pypromice/L0toL1.py
+++ b/src/pypromice/L0toL1.py
@@ -8,13 +8,15 @@ import pandas as pd
 import xarray as xr
 import re
 
-def toL1(L0, flag_file=None, T_0=273.15, tilt_threshold=-100):
+def toL1(L0, vars_df, flag_file=None, T_0=273.15, tilt_threshold=-100):
     '''Process one Level 0 (L0) product to Level 1
 
     Parameters
     ----------
     L0 : xarray.Dataset
         Level 0 dataset
+    vars_df : pd.DataFrame
+        Metadata dataframe
     flag_file : str
         Flag .csv file path for bad data
     T_0 : int
@@ -45,7 +47,7 @@ def toL1(L0, flag_file=None, T_0=273.15, tilt_threshold=-100):
     ds = ds.isel(time=index)
 
     # If we do not want to shift hourly average values back -1 hr, then comment the following line.
-    ds = _addTimeShift(ds)
+    ds = _addTimeShift(ds, vars_df)
 
     if hasattr(ds, 'dsr_eng_coef'): 
         ds['dsr'] = (ds['dsr'] * 10) / ds.attrs['dsr_eng_coef']                # Convert radiation from engineering to physical units
@@ -225,29 +227,32 @@ def _popCols(ds, booms, data_type, vars_df, cols):
 #             ds[v] = (('time'), np.arange(ds['time'].size)*np.nan)      
 #     return ds
 
-def _addTimeShift(ds):
-    '''Adjust times based on file format and logger type (including only hourly averaged values,
-    and discluding instantaneous or GPS variables). For raw (10 min), all values are sampled
-    instantaneously so do not shift. For STM (1 hour), values are averaged and assigned to end-of-hour
-    by the logger, so times are shifted by -1 hr. For TX (time frequency depends on v2 or v3) then
-    time is shifted depending on logger type.
+def _addTimeShift(ds, vars_df):
+    '''Shift times based on file format and logger type (shifting only hourly averaged values,
+    and not instantaneous variables). For raw (10 min), all values are sampled instantaneously
+    so do not shift. For STM (1 hour), values are averaged and assigned to end-of-hour by the
+    logger, so shift by -1 hr. For TX (time frequency depends on v2 or v3) then time is shifted
+    depending on logger type. We use the 'instantaneous_hourly' boolean from variables.csv to
+    determine if a variable is considered instantaneous at hourly samples.
 
     This approach creates two separate sub-dataframes, one for hourly-averaged variables
-    and another for instantaneous and GPS variables. The instantaneous dataframe should
-    never be shifted. We apply shifting only to the hourly average dataframe, then concat
-    the two dataframes back together.
+    and another for instantaneous variables. The instantaneous dataframe should never be
+    shifted. We apply shifting only to the hourly average dataframe, then concat the two
+    dataframes back together.
 
     It is possible to use pandas merge or join instead of concat, there are equivalent methods
     in each. In this case, we use concat throughout.
 
     Fausto et al. 2021 specifies the convention of assigning hourly averages to start-of-hour,
     so we need to retain this unless clearly communicated to users.
-    
+
     Parameters
     ----------
     ds : xarray.Dataset
         Dataset to apply time shift to
-    
+    vars_df : pd.DataFrame
+        Metadata dataframe
+
     Returns
     -------
     ds_out : xarray.Dataset
@@ -257,44 +262,50 @@ def _addTimeShift(ds):
     # No need to drop duplicates if performed prior to calling this function.
     # df = df[~df.index.duplicated(keep='first')] # drop duplicates, keep=first is arbitrary
     df['doy'] = df.index.dayofyear
-    i_cols = [x for x in df.columns if '_i' in x or 'gps_' in x or 'msg_' in x] # instantaneous only, list of columns
-    df_i = df.filter(items=i_cols, axis=1).drop(columns='batt_v_ini') # instantaneous only dataframe
-    df_u = df.drop(df_i.columns, axis=1) # hourly ave dataframe
+    i_cols = [x for x in df.columns if x in vars_df.index and vars_df['instantaneous_hourly'][x] is True] # instantaneous only, list of columns
+    df_i = df.filter(items=i_cols, axis=1) # instantaneous only dataframe
+    df_a = df.drop(df_i.columns, axis=1) # hourly ave dataframe
 
     if ds.attrs['format'] == 'raw':
         # 10-minute data, no shifting
         df_out = df
     elif ds.attrs['format'] == 'STM':
         # hourly-averaged, non-transmitted
-        # shift everything except instantaneous and gps vars, any logger type
-        df_u = df_u.shift(periods=-1, freq="H")
-        df_out = pd.concat([df_u, df_i], axis=1) # different columns, same datetime indices
+        # shift everything except instantaneous, any logger type
+        df_a = df_a.shift(periods=-1, freq="H")
+        df_out = pd.concat([df_a, df_i], axis=1) # different columns, same datetime indices
     elif ds.attrs['format'] == 'TX':
         if ds.attrs['logger_type'] == 'CR1000X':
             # v3, data is hourly all year long
-            # shift everything except instantaneous and gps vars
-            df_u = df_u.shift(periods=-1, freq="H")
-            df_out = pd.concat([df_u, df_i], axis=1) # different columns, same datetime indices
+            # shift everything except instantaneous
+            df_a = df_a.shift(periods=-1, freq="H")
+            df_out = pd.concat([df_a, df_i], axis=1) # different columns, same datetime indices
         elif ds.attrs['logger_type'] == 'CR1000':
             # v2, data is hourly (6-hr for instantaneous) for DOY 100-300, otherwise daily at 00 UTC
             # shift non-instantaneous hourly for DOY 100-300, else do not shift daily
-            df_u_hourly = df_u.loc[(df_u['doy'] >= 100) & (df_u['doy'] <= 300)]
-            # df_u_hourly = df_u.loc[df_u['doy'].between(100, 300, inclusive='both')] # equivalent to above
-            df_u_daily_1 = df_u.loc[(df_u['doy'] < 100)]
-            df_u_daily_2 = df_u.loc[(df_u['doy'] > 300)]
+            df_a_hourly = df_a.loc[(df_a['doy'] >= 100) & (df_a['doy'] <= 300)]
+            # df_a_hourly = df_a.loc[df_a['doy'].between(100, 300, inclusive='both')] # equivalent to above
+            df_a_daily_1 = df_a.loc[(df_a['doy'] < 100)]
+            df_a_daily_2 = df_a.loc[(df_a['doy'] > 300)]
 
             # shift the hourly ave data
-            df_u_hourly = df_u_hourly.shift(periods=-1, freq="H")
+            df_a_hourly = df_a_hourly.shift(periods=-1, freq="H")
 
             # stitch everything back together
-            df_concat_u = pd.concat([df_u_daily_1, df_u_daily_2, df_u_hourly], axis=0) # same columns, different datetime indices
+            df_concat_u = pd.concat([df_a_daily_1, df_a_daily_2, df_a_hourly], axis=0) # same columns, different datetime indices
             df_out = pd.concat([df_concat_u, df_i], axis=1) # different columns, same datetime indices
             df_out = df_out.sort_index()
 
     # Back to xarray, and re-assign the original attrs
+    df_out = df_out.drop('doy', axis=1)
     ds_out = df_out.to_xarray()
-    ds_out = ds_out.assign_attrs(ds.attrs)
+    ds_out = ds_out.assign_attrs(ds.attrs) # Dataset attrs
+    for x in ds_out.data_vars: # variable-specific attrs
+        ds_out[x].attrs = ds[x].attrs
 
+    # equivalent to above:
+    # vals = [xr.DataArray(data=df_out[c], dims=['time'], coords={'time':df_out.index}, attrs=ds[c].attrs) for c in df_out.columns]
+    # ds_out = xr.Dataset(dict(zip(df_out.columns, vals)), attrs=ds.attrs)
     return ds_out
 
 def _removeVars(ds, v_names):

--- a/src/pypromice/aws.py
+++ b/src/pypromice/aws.py
@@ -21,7 +21,6 @@ except:
 pd.set_option('display.precision', 2)
 xr.set_options(keep_attrs=True)
 
-# from IPython import embed
 #------------------------------------------------------------------------------
 
 class AWS(object):

--- a/src/pypromice/aws.py
+++ b/src/pypromice/aws.py
@@ -111,7 +111,7 @@ class AWS(object):
         
         print('Level 1 processing...')
         self.L0 = [addBasicMeta(item, self.vars) for item in self.L0]
-        self.L1 = [toL1(item) for item in self.L0]
+        self.L1 = [toL1(item, self.vars) for item in self.L0]
         self.L1A = mergeVars(self.L1, self.vars)
         
         # L1 to L2 processing
@@ -723,7 +723,7 @@ def getVars(v_file):
    
    Parameters
    ----------
-   v_file : str I've moved back here  I've moved back here 
+   v_file : str
        Variable lookup table file path
 
    Returns

--- a/src/pypromice/test/test_config1.toml
+++ b/src/pypromice/test/test_config1.toml
@@ -1,4 +1,5 @@
 station_id = 'TEST1'
+logger_type = 'CR1000X'
 nodata     = ['-999', 'NAN'] # if one is a string, all must be strings
 number_of_booms = 1 #1-boom = promice, 2-boom = gc-net
 latitude = 79.91

--- a/src/pypromice/test/test_config2.toml
+++ b/src/pypromice/test/test_config2.toml
@@ -1,4 +1,5 @@
 station_id = 'TEST2'
+logger_type = 'CR1000X'
 nodata     = ['-999', 'NAN'] # if one is a string, all must be strings
 number_of_booms = 2
 

--- a/src/pypromice/variables.csv
+++ b/src/pypromice/variables.csv
@@ -1,94 +1,94 @@
-field,standard_name,long_name,units,lo,hi,OOL,station_type,data_type,max_decimals,coverage_content_type,coordinates,comment
-time,time,Time,yyyy-mm-dd HH:MM:SS,,,,all,all,,physicalMeasurement,time lat lon alt,
-rec,record,Record,-,,,,all,,0,referenceInformation,time lat lon alt,L0 only
-p_u,air_pressure,Air pressure (upper boom),hPa,650,1100,z_pt z_pt_cor dshf_u dlhf_u qh_u,all,all,4,physicalMeasurement,time lat lon alt,
-p_l,air_pressure,Air pressure (lower boom),hPa,650,1100,dshf_l dlhf_l qh_l,two-boom,all,4,physicalMeasurement,time lat lon alt,
-t_u,air_temperature,Air temperature (upper boom),degrees_C,-80,40,rh_u_cor cc dsr_cor usr_cor z_boom z_stake dshf_u dlhf_u qh_u,all,all,4,physicalMeasurement,time lat lon alt,
-t_l,air_temperature,Air temperature (lower boom),degrees_C,-80,40,rh_l_cor z_boom_l dshf_l dlhf_l qh_l ,two-boom,all,4,physicalMeasurement,time lat lon alt,PT100 temperature at boom
-rh_u,relative_humidity,Relative humidity (upper boom),%,0,150,rh_u_cor,all,all,4,physicalMeasurement,time lat lon alt,
-rh_u_cor,relative_humidity_corrected,Relative humidity (upper boom) - corrected,%,0,100,dshf_u dlhf_u qh_u,all,all,4,modelResult,time lat lon alt,
-qh_u,specific_humidity,Specific humidity (upper boom),%,0,100,,all,all,4,modelResult,time lat lon alt,Derived value (L2 or later)
-rh_l,relative_humidity,Relative humidity (lower boom),%,0,150,rh_l_cor,two-boom,all,4,physicalMeasurement,time lat lon alt,
-rh_l_cor,relative_humidity_corrected,Relative humidity (lower boom) - corrected,%,0,100,dshf_l dlhf_l qh_l,two-boom,all,4,modelResult,time lat lon alt,
-qh_l,specific_humidity,Specific humidity (lower boom),%,0,100,,two-boom,all,4,modelResult,time lat lon alt,Derived value (L2 or later)
-wspd_u,wind_speed,Wind speed (upper boom),m s-1,0,100,"wdir_u wspd_x_u wspd_y_u dshf_u dlhf_u qh_u, precip_u",all,all,4,physicalMeasurement,time lat lon alt,
-wspd_l,wind_speed,Wind speed (lower boom),m s-1,0,100,"wdir_l wspd_x_l wspd_y_l dshf_l dlhf_l qh_l , precip_l",two-boom,all,4,physicalMeasurement,time lat lon alt,
-wdir_u,wind_from_direction,Wind from direction (upper boom),degrees,1,360,wspd_x_u wspd_y_u,all,all,4,physicalMeasurement,time lat lon alt,
-wdir_std_u,wind_from_direction_standard_deviation,Wind from direction (standard deviation),degrees,,,,one-boom,,4,qualityInformation,time lat lon alt,L0 only
-wdir_l,wind_from_direction,Wind from direction (lower boom),degrees,1,360,wspd_x_l wspd_y_l,two-boom,all,4,physicalMeasurement,time lat lon alt,
-wspd_x_u,wind_speed_from_x_direction,Wind speed from x direction (upper boom),m s-1,-100,100,wdir_u wspd_u,all,,4,modelResult,time lat lon alt,L0 only
-wspd_y_u,wind_speed_from_y_direction,Wind speed from y direction (upper boom),m s-1,-100,100,wdir_u wspd_u,all,,4,modelResult,time lat lon alt,L0 only
-wspd_x_l,wind_speed_from_x_direction,Wind speed from x direction (lower boom),m s-1,-100,100,wdir_l wspd_l,two-boom,,4,modelResult,time lat lon alt,L0 only
-wspd_y_l,wind_speed_from_y_direction,Wind speed from y direction (lower boom),m s-1,-100,100,wdir_l wspd_l,two-boom,,4,modelResult,time lat lon alt,L0 only
-dsr,surface_downwelling_shortwave_flux,Downwelling shortwave radiation,W m-2,-10,1500,albedo dsr_cor usr_cor,all,all,4,physicalMeasurement,time lat lon alt,"Actually radiation_at_sensor, not flux. Units 1E-5 V. Engineering units."
-dsr_cor,surface_downwelling_shortwave_flux_corrected,Downwelling shortwave radiation - corrected,W m-2,,,,all,all,4,modelResult,time lat lon alt,Derived value (L2 or later)
-usr,surface_upwelling_shortwave_flux,Upwelling shortwave radiation,W m-2,-10,1000,albedo dsr_cor usr_cor,all,all,4,physicalMeasurement,time lat lon alt,
-usr_cor,surface_upwelling_shortwave_flux_corrected,Upwelling shortwave radiation - corrected,W m-2,0,1000,,all,all,4,modelResult,time lat lon alt,Derived value (L2 or later)
-albedo,surface_albedo,Albedo,-,,,,all,all,4,modelResult,time lat lon alt,Derived value (L2 or later)
-dlr,surface_downwelling_longwave_flux,Downwelling longwave radiation,W m-2,50,500,albedo dsr_cor usr_cor cc t_surf,all,all,4,physicalMeasurement,time lat lon alt,
-ulr,surface_upwelling_longwave_flux,Upwelling longwave radiation,W m-2,50,500,t_surf,all,all,4,physicalMeasurement,time lat lon alt,
-cc,cloud_area_fraction,Cloud cover,%,,,,all,all,4,modelResult,time lat lon alt,Derived value (L2 or later)
-t_surf,surface_temperature,Surface temperature,C,-80,40,dshf_u dlhf_u qh_u,all,all,4,modelResult,time lat lon alt,Derived value (L2 or later)
-dlhf_u,surface_downward_latent_heat_flux,Latent heat flux (upper boom),W m-2,,,,all,all,4,modelResult,time lat lon alt,Derived value (L2 or later)
-dlhf_l,surface_downward_latent_heat_flux,Latent heat flux (lower boom),W m-2,,,,two-boom,all,4,modelResult,time lat lon alt,Derived value (L2 or later)
-dshf_u,surface_downward_sensible_heat_flux,Sensible heat flux (upper boom),W m-2,,,,all,all,4,modelResult,time lat lon alt,Derived value (L2 or later)
-dshf_l,surface_downward_sensible_heat_flux,Sensible heat flux (lower boom),W m-2,,,,two-boom,all,4,modelResult,time lat lon alt,Derived value (L2 or later)
-z_boom_u,distance_to_surface_from_boom,Upper boom height,m,0.3,10,dshf_u dlhf_u qh_u,all,all,4,physicalMeasurement,time lat lon alt,
-z_boom_q_u,distance_to_surface_from_boom_quality,Upper boom height (quality),-,,,,all,,4,qualityInformation,time lat lon alt,L0 only
-z_boom_l,distance_to_surface_from_boom,Lower boom height,m,0.3,5,dshf_l dlhf_l qh_l,two-boom,all,4,physicalMeasurement,time lat lon alt,
-z_boom_q_l,distance_to_surface_from_boom_quality,Loer boom height (quality),-,,,,two-boom,,4,qualityInformation,time lat lon alt,L0 only
-z_stake,distance_to_surface_from_stake_assembly,Stake height,m,0.3,8,,one-boom,all,4,physicalMeasurement,time lat lon alt,HeightStakes(m)
-z_stake_q,distance_to_surface_from_stake_assembly_quality,Stake height (quality),-,,,,one-boom,,4,qualityInformation,time lat lon alt,L0 only
-z_pt,depth_of_pressure_transducer_in_ice,Depth of pressure transducer in ice,m,0,30,z_pt_cor,one-boom,all,4,physicalMeasurement,time lat lon alt,DepthPressureTransducer(m)
-z_pt_cor,depth_of_pressure_transducer_in_ice_corrected,Depth of pressure transducer in ice - corrected,m,0,30,,one-boom,all,4,modelResult,time lat lon alt,Derived value (L2 or later)
-precip_u,precipitation,Precipitation (upper boom) (cumulative solid & liquid),mm,0,,precip_u_cor precip_u_rate,all,all,4,physicalMeasurement,time lat lon alt,Without wind/undercatch correction
-precip_u_cor,precipitation_corrected,Precipitation (upper boom) (cumulative solid & liquid) – corrected,mm,0,,,all,all,4,modelResult,time lat lon alt,With wind/undercatch correction
-precip_u_rate,precipitation_rate,Precipitation rate (upper boom) (cumulative solid & liquid) – corrected,mm,0,,,all,,4,modelResult,time lat lon alt,L0 only
-precip_l,precipitation,Precipitation (lower boom) (cumulative solid & liquid),mm,0,,precip_l_cor precip_l_rate,two-boom,all,4,physicalMeasurement,time lat lon alt,Without wind/undercatch correction
-precip_l_cor,precipitation_corrected,Precipitation (lower boom) (cumulative solid & liquid) – corrected,mm,0,,,two-boom,all,4,modelResult,time lat lon alt,With wind/undercatch correction
-precip_l_rate,precipitation_rate,Precipitation rate (lower boom) (cumulative solid & liquid) – corrected,mm,0,,,two-boom,,4,modelResult,time lat lon alt,L0 only
-t_i_1,ice_temperature_at_t1,Ice temperature at sensor 1,degrees_C,-80,40,,all,all,4,physicalMeasurement,time lat lon alt,t1 is installed @ 1 m depth
-t_i_2,ice_temperature_at_t2,Ice temperature at sensor 2,degrees_C,-80,40,,all,all,4,physicalMeasurement,time lat lon alt,
-t_i_3,ice_temperature_at_t3,Ice temperature at sensor 3,degrees_C,-80,40,,all,all,4,physicalMeasurement,time lat lon alt,
-t_i_4,ice_temperature_at_t4,Ice temperature at sensor 4,degrees_C,-80,40,,all,all,4,physicalMeasurement,time lat lon alt,
-t_i_5,ice_temperature_at_t5,Ice temperature at sensor 5,degrees_C,-80,40,,all,all,4,physicalMeasurement,time lat lon alt,
-t_i_6,ice_temperature_at_t6,Ice temperature at sensor 6,degrees_C,-80,40,,all,all,4,physicalMeasurement,time lat lon alt,
-t_i_7,ice_temperature_at_t7,Ice temperature at sensor 7,degrees_C,-80,40,,all,all,4,physicalMeasurement,time lat lon alt,
-t_i_8,ice_temperature_at_t8,Ice temperature at sensor 8,degrees_C,-80,40,,all,all,4,physicalMeasurement,time lat lon alt,t8 is installed @ 10 m depth
-t_i_9,ice_temperature_at_t9,Ice temperature at sensor 9,degrees_C,-80,40,,two-boom,all,4,physicalMeasurement,time lat lon alt,
-t_i_10,ice_temperature_at_t10,Ice temperature at sensor 10,degrees_C,-80,40,,two-boom,all,4,physicalMeasurement,time lat lon alt,
-t_i_11,ice_temperature_at_t11,Ice temperature at sensor 11,degrees_C,-80,40,,two-boom,all,4,physicalMeasurement,time lat lon alt,
-tilt_x,platform_view_angle_x,Tilt to east,degrees,-30,30,dsr_cor usr_cor albedo,all,all,4,physicalMeasurement,time lat lon alt,
-tilt_y,platform_view_angle_y,Tilt to north,degrees,-30,30,dsr_cor usr_cor albedo,all,all,4,physicalMeasurement,time lat lon alt,
-rot,platform_azimuth_angle,Station rotation from true North,degrees,0,360,,all,all,2,physicalMeasurement,time lat lon alt,v4 addition
-gps_lat,gps_latitude,Latitude,degrees_north,50,83,,all,all,6,coordinate,time lat lon alt,
-gps_lon,gps_longitude,Longitude,degrees_east,5,70,,all,all,6,coordinate,time lat lon alt,
-gps_alt,gps_altitude,Altitude,m,0,3000,,all,all,2,coordinate,time lat lon alt,
-gps_time,gps_time,GPS time,s,0,240000,,all,all,,coordinate,time lat lon alt,
-gps_geoid,gps_geoid_separation,Height of EGM96 geoid over WGS84 ellipsoid,m,,,,one-boom,all,,physicalMeasurement,time lat lon alt,
-gps_geounit,gps_geounit,GeoUnit,-,,,,all,raw,,qualityInformation,time lat lon alt,
-gps_hdop,gps_hdop,GPS horizontal dillution of precision (HDOP),m,,,,all,all,2,qualityInformation,time lat lon alt,NMEA: Horizontal dilution of precision
-gps_numsat,gps_numsat,GPS number of satellites,-,,,,one-boom,all,0,qualityInformation,time lat lon alt,
-gps_q,gps_q,Quality,-,,,,one-boom,all,,qualityInformation,time lat lon alt,
-lat,gps_mean_latitude,GPS mean latitude (from all time-series),degrees,,,,all,,6,modelResult,time lat lon alt,
-lon,gps_mean_longitude,GPS mean longitude (from all time-series),degrees,,,,all,,6,modelResult,time lat lon alt,
-alt,gps_mean_altitude,GPS mean altitude (from all time-series),degrees,,,,all,,6,modelResult,time lat lon alt,
-batt_v,battery_voltage,Battery voltage,V,0,30,,all,all,2,physicalMeasurement,time lat lon alt,
-batt_v_ini,,,-,0,30,,one-boom,all,2,physicalMeasurement,time lat lon alt,
-batt_v_ss,battery_voltage_at_sample_start,Battery voltage (sample start),V,0,30,,one-boom,all,2,physicalMeasurement,time lat lon alt,
-fan_dc_u,fan_current,Fan current (upper boom),mA,0,200,,all,all,2,physicalMeasurement,time lat lon alt,
-fan_dc_l,fan_current,Fan current (lower boom),mA,0,200,,two-boom,all,2,physicalMeasurement,time lat lon alt,
-freq_vw,frequency_of_precipitation_wire_vibration,Frequency of vibrating wire in precipitation gauge,Hz,0,10000,precip_u,one-boom,all,,physicalMeasurement,time lat lon alt,
-t_log,temperature_of_logger,Logger temperature,degrees_C,-80,40,,one-boom,all,4,physicalMeasurement,time lat lon alt,LoggerTemperature(C)
-t_rad,temperature_of_radiation_sensor,Radiation sensor temperature,degrees_C,-80,40,t_surf dlr ulr,all,all,4,physicalMeasurement,time lat lon alt,
-p_i,air_pressure,Air pressure (instantaneous) minus 1000,hPa,-350,100,,all,TX,4,physicalMeasurement,time lat lon alt,For meteorological observations
-t_i,air_temperature,Air temperature (instantaneous),degrees_C,-80,40,,all,TX,4,physicalMeasurement,time lat lon alt,"PT100 temperature at boom, for meteorological observations"
-rh_i,relative_humidity,Relative humidity (instantaneous),%,0,150,rh_i_cor,all,TX,4,physicalMeasurement,time lat lon alt,For meteorological observations
-rh_i_cor,relative_humidity_corrected,Relative humidity (instantaneous) – corrected,%,0,100,,all,TX,4,modelResult,time lat lon alt,For meteorological observations
-wspd_i,wind_speed,Wind speed (instantaneous),m s-1,0,100,wdir_i wspd_x_i wspd_y_i,all,TX,4,physicalMeasurement,time lat lon alt,For meteorological observations
-wdir_i,wind_from_direction,Wind from direction (instantaneous),degrees,1,360,wspd_x_i wspd_y_i,all,TX,4,physicalMeasurement,time lat lon alt,For meteorological observations
-wspd_x_i,wind_speed_from_x_direction,Wind speed from x direction (instantaneous),m s-1,-100,100,wdir_i wspd_i,all,,4,modelResult,time lat lon alt,For meteorological observations
-wspd_y_i,wind_speed_from_y_direction,Wind speed from y direction (instantaneous),m s-1,-100,100,wdir_i wspd_i,all,,4,modelResult,time lat lon alt,For meteorological observations
-msg_i,message,Message string (instantaneous),-,,,,all,TX,,qualityInformation,time lat lon alt,For meteorological observations
-msg_lat,message_latitude,latitude from modem (email text),degrees_north,50,83,,all,all,6,coordinate,time lat lon alt,
-msg_lon,message_longitude,longitude from modem (email text),degrees_east,-72,13,,all,all,6,coordinate,time lat lon alt,
+field,standard_name,long_name,units,lo,hi,OOL,station_type,data_type,max_decimals,coverage_content_type,coordinates,instantaneous_hourly,comment
+time,time,Time,yyyy-mm-dd HH:MM:SS,,,,all,all,,physicalMeasurement,time lat lon alt,,
+rec,record,Record,-,,,,all,,0,referenceInformation,time lat lon alt,,L0 only
+p_u,air_pressure,Air pressure (upper boom),hPa,650,1100,z_pt z_pt_cor dshf_u dlhf_u qh_u,all,all,4,physicalMeasurement,time lat lon alt,False,
+p_l,air_pressure,Air pressure (lower boom),hPa,650,1100,dshf_l dlhf_l qh_l,two-boom,all,4,physicalMeasurement,time lat lon alt,False,
+t_u,air_temperature,Air temperature (upper boom),degrees_C,-80,40,rh_u_cor cc dsr_cor usr_cor z_boom z_stake dshf_u dlhf_u qh_u,all,all,4,physicalMeasurement,time lat lon alt,False,
+t_l,air_temperature,Air temperature (lower boom),degrees_C,-80,40,rh_l_cor z_boom_l dshf_l dlhf_l qh_l ,two-boom,all,4,physicalMeasurement,time lat lon alt,False,PT100 temperature at boom
+rh_u,relative_humidity,Relative humidity (upper boom),%,0,150,rh_u_cor,all,all,4,physicalMeasurement,time lat lon alt,False,
+rh_u_cor,relative_humidity_corrected,Relative humidity (upper boom) - corrected,%,0,100,dshf_u dlhf_u qh_u,all,all,4,modelResult,time lat lon alt,False,
+qh_u,specific_humidity,Specific humidity (upper boom),%,0,100,,all,all,4,modelResult,time lat lon alt,False,Derived value (L2 or later)
+rh_l,relative_humidity,Relative humidity (lower boom),%,0,150,rh_l_cor,two-boom,all,4,physicalMeasurement,time lat lon alt,False,
+rh_l_cor,relative_humidity_corrected,Relative humidity (lower boom) - corrected,%,0,100,dshf_l dlhf_l qh_l,two-boom,all,4,modelResult,time lat lon alt,False,
+qh_l,specific_humidity,Specific humidity (lower boom),%,0,100,,two-boom,all,4,modelResult,time lat lon alt,False,Derived value (L2 or later)
+wspd_u,wind_speed,Wind speed (upper boom),m s-1,0,100,"wdir_u wspd_x_u wspd_y_u dshf_u dlhf_u qh_u, precip_u",all,all,4,physicalMeasurement,time lat lon alt,False,
+wspd_l,wind_speed,Wind speed (lower boom),m s-1,0,100,"wdir_l wspd_x_l wspd_y_l dshf_l dlhf_l qh_l , precip_l",two-boom,all,4,physicalMeasurement,time lat lon alt,False,
+wdir_u,wind_from_direction,Wind from direction (upper boom),degrees,1,360,wspd_x_u wspd_y_u,all,all,4,physicalMeasurement,time lat lon alt,False,
+wdir_std_u,wind_from_direction_standard_deviation,Wind from direction (standard deviation),degrees,,,,one-boom,,4,qualityInformation,time lat lon alt,False,L0 only
+wdir_l,wind_from_direction,Wind from direction (lower boom),degrees,1,360,wspd_x_l wspd_y_l,two-boom,all,4,physicalMeasurement,time lat lon alt,False,
+wspd_x_u,wind_speed_from_x_direction,Wind speed from x direction (upper boom),m s-1,-100,100,wdir_u wspd_u,all,,4,modelResult,time lat lon alt,False,L0 only
+wspd_y_u,wind_speed_from_y_direction,Wind speed from y direction (upper boom),m s-1,-100,100,wdir_u wspd_u,all,,4,modelResult,time lat lon alt,False,L0 only
+wspd_x_l,wind_speed_from_x_direction,Wind speed from x direction (lower boom),m s-1,-100,100,wdir_l wspd_l,two-boom,,4,modelResult,time lat lon alt,False,L0 only
+wspd_y_l,wind_speed_from_y_direction,Wind speed from y direction (lower boom),m s-1,-100,100,wdir_l wspd_l,two-boom,,4,modelResult,time lat lon alt,False,L0 only
+dsr,surface_downwelling_shortwave_flux,Downwelling shortwave radiation,W m-2,-10,1500,albedo dsr_cor usr_cor,all,all,4,physicalMeasurement,time lat lon alt,False,"Actually radiation_at_sensor, not flux. Units 1E-5 V. Engineering units."
+dsr_cor,surface_downwelling_shortwave_flux_corrected,Downwelling shortwave radiation - corrected,W m-2,,,,all,all,4,modelResult,time lat lon alt,False,Derived value (L2 or later)
+usr,surface_upwelling_shortwave_flux,Upwelling shortwave radiation,W m-2,-10,1000,albedo dsr_cor usr_cor,all,all,4,physicalMeasurement,time lat lon alt,False,
+usr_cor,surface_upwelling_shortwave_flux_corrected,Upwelling shortwave radiation - corrected,W m-2,0,1000,,all,all,4,modelResult,time lat lon alt,False,Derived value (L2 or later)
+albedo,surface_albedo,Albedo,-,,,,all,all,4,modelResult,time lat lon alt,False,Derived value (L2 or later)
+dlr,surface_downwelling_longwave_flux,Downwelling longwave radiation,W m-2,50,500,albedo dsr_cor usr_cor cc t_surf,all,all,4,physicalMeasurement,time lat lon alt,False,
+ulr,surface_upwelling_longwave_flux,Upwelling longwave radiation,W m-2,50,500,t_surf,all,all,4,physicalMeasurement,time lat lon alt,False,
+cc,cloud_area_fraction,Cloud cover,%,,,,all,all,4,modelResult,time lat lon alt,False,Derived value (L2 or later)
+t_surf,surface_temperature,Surface temperature,C,-80,40,dshf_u dlhf_u qh_u,all,all,4,modelResult,time lat lon alt,False,Derived value (L2 or later)
+dlhf_u,surface_downward_latent_heat_flux,Latent heat flux (upper boom),W m-2,,,,all,all,4,modelResult,time lat lon alt,False,Derived value (L2 or later)
+dlhf_l,surface_downward_latent_heat_flux,Latent heat flux (lower boom),W m-2,,,,two-boom,all,4,modelResult,time lat lon alt,False,Derived value (L2 or later)
+dshf_u,surface_downward_sensible_heat_flux,Sensible heat flux (upper boom),W m-2,,,,all,all,4,modelResult,time lat lon alt,False,Derived value (L2 or later)
+dshf_l,surface_downward_sensible_heat_flux,Sensible heat flux (lower boom),W m-2,,,,two-boom,all,4,modelResult,time lat lon alt,False,Derived value (L2 or later)
+z_boom_u,distance_to_surface_from_boom,Upper boom height,m,0.3,10,dshf_u dlhf_u qh_u,all,all,4,physicalMeasurement,time lat lon alt,True,
+z_boom_q_u,distance_to_surface_from_boom_quality,Upper boom height (quality),-,,,,all,,4,qualityInformation,time lat lon alt,True,L0 only
+z_boom_l,distance_to_surface_from_boom,Lower boom height,m,0.3,5,dshf_l dlhf_l qh_l,two-boom,all,4,physicalMeasurement,time lat lon alt,True,
+z_boom_q_l,distance_to_surface_from_boom_quality,Loer boom height (quality),-,,,,two-boom,,4,qualityInformation,time lat lon alt,True,L0 only
+z_stake,distance_to_surface_from_stake_assembly,Stake height,m,0.3,8,,one-boom,all,4,physicalMeasurement,time lat lon alt,True,HeightStakes(m)
+z_stake_q,distance_to_surface_from_stake_assembly_quality,Stake height (quality),-,,,,one-boom,,4,qualityInformation,time lat lon alt,True,L0 only
+z_pt,depth_of_pressure_transducer_in_ice,Depth of pressure transducer in ice,m,0,30,z_pt_cor,one-boom,all,4,physicalMeasurement,time lat lon alt,False,DepthPressureTransducer(m)
+z_pt_cor,depth_of_pressure_transducer_in_ice_corrected,Depth of pressure transducer in ice - corrected,m,0,30,,one-boom,all,4,modelResult,time lat lon alt,False,Derived value (L2 or later)
+precip_u,precipitation,Precipitation (upper boom) (cumulative solid & liquid),mm,0,,precip_u_cor precip_u_rate,all,all,4,physicalMeasurement,time lat lon alt,True,Without wind/undercatch correction
+precip_u_cor,precipitation_corrected,Precipitation (upper boom) (cumulative solid & liquid) – corrected,mm,0,,,all,all,4,modelResult,time lat lon alt,True,With wind/undercatch correction
+precip_u_rate,precipitation_rate,Precipitation rate (upper boom) (cumulative solid & liquid) – corrected,mm,0,,,all,,4,modelResult,time lat lon alt,True,L0 only
+precip_l,precipitation,Precipitation (lower boom) (cumulative solid & liquid),mm,0,,precip_l_cor precip_l_rate,two-boom,all,4,physicalMeasurement,time lat lon alt,True,Without wind/undercatch correction
+precip_l_cor,precipitation_corrected,Precipitation (lower boom) (cumulative solid & liquid) – corrected,mm,0,,,two-boom,all,4,modelResult,time lat lon alt,True,With wind/undercatch correction
+precip_l_rate,precipitation_rate,Precipitation rate (lower boom) (cumulative solid & liquid) – corrected,mm,0,,,two-boom,,4,modelResult,time lat lon alt,True,L0 only
+t_i_1,ice_temperature_at_t1,Ice temperature at sensor 1,degrees_C,-80,40,,all,all,4,physicalMeasurement,time lat lon alt,True,t1 is installed @ 1 m depth
+t_i_2,ice_temperature_at_t2,Ice temperature at sensor 2,degrees_C,-80,40,,all,all,4,physicalMeasurement,time lat lon alt,True,
+t_i_3,ice_temperature_at_t3,Ice temperature at sensor 3,degrees_C,-80,40,,all,all,4,physicalMeasurement,time lat lon alt,True,
+t_i_4,ice_temperature_at_t4,Ice temperature at sensor 4,degrees_C,-80,40,,all,all,4,physicalMeasurement,time lat lon alt,True,
+t_i_5,ice_temperature_at_t5,Ice temperature at sensor 5,degrees_C,-80,40,,all,all,4,physicalMeasurement,time lat lon alt,True,
+t_i_6,ice_temperature_at_t6,Ice temperature at sensor 6,degrees_C,-80,40,,all,all,4,physicalMeasurement,time lat lon alt,True,
+t_i_7,ice_temperature_at_t7,Ice temperature at sensor 7,degrees_C,-80,40,,all,all,4,physicalMeasurement,time lat lon alt,True,
+t_i_8,ice_temperature_at_t8,Ice temperature at sensor 8,degrees_C,-80,40,,all,all,4,physicalMeasurement,time lat lon alt,True,t8 is installed @ 10 m depth
+t_i_9,ice_temperature_at_t9,Ice temperature at sensor 9,degrees_C,-80,40,,two-boom,all,4,physicalMeasurement,time lat lon alt,True,
+t_i_10,ice_temperature_at_t10,Ice temperature at sensor 10,degrees_C,-80,40,,two-boom,all,4,physicalMeasurement,time lat lon alt,True,
+t_i_11,ice_temperature_at_t11,Ice temperature at sensor 11,degrees_C,-80,40,,two-boom,all,4,physicalMeasurement,time lat lon alt,True,
+tilt_x,platform_view_angle_x,Tilt to east,degrees,-30,30,dsr_cor usr_cor albedo,all,all,4,physicalMeasurement,time lat lon alt,False,
+tilt_y,platform_view_angle_y,Tilt to north,degrees,-30,30,dsr_cor usr_cor albedo,all,all,4,physicalMeasurement,time lat lon alt,False,
+rot,platform_azimuth_angle,Station rotation from true North,degrees,0,360,,all,all,2,physicalMeasurement,time lat lon alt,False,v4 addition
+gps_lat,gps_latitude,Latitude,degrees_north,50,83,,all,all,6,coordinate,time lat lon alt,True,
+gps_lon,gps_longitude,Longitude,degrees_east,5,70,,all,all,6,coordinate,time lat lon alt,True,
+gps_alt,gps_altitude,Altitude,m,0,3000,,all,all,2,coordinate,time lat lon alt,True,
+gps_time,gps_time,GPS time,s,0,240000,,all,all,,coordinate,time lat lon alt,True,
+gps_geoid,gps_geoid_separation,Height of EGM96 geoid over WGS84 ellipsoid,m,,,,one-boom,all,,physicalMeasurement,time lat lon alt,True,
+gps_geounit,gps_geounit,GeoUnit,-,,,,all,raw,,qualityInformation,time lat lon alt,True,
+gps_hdop,gps_hdop,GPS horizontal dillution of precision (HDOP),m,,,,all,all,2,qualityInformation,time lat lon alt,True,NMEA: Horizontal dilution of precision
+gps_numsat,gps_numsat,GPS number of satellites,-,,,,one-boom,all,0,qualityInformation,time lat lon alt,True,
+gps_q,gps_q,Quality,-,,,,one-boom,all,,qualityInformation,time lat lon alt,True,
+lat,gps_mean_latitude,GPS mean latitude (from all time-series),degrees,,,,all,,6,modelResult,time lat lon alt,True,
+lon,gps_mean_longitude,GPS mean longitude (from all time-series),degrees,,,,all,,6,modelResult,time lat lon alt,True,
+alt,gps_mean_altitude,GPS mean altitude (from all time-series),degrees,,,,all,,6,modelResult,time lat lon alt,True,
+batt_v,battery_voltage,Battery voltage,V,0,30,,all,all,2,physicalMeasurement,time lat lon alt,True,
+batt_v_ini,,,-,0,30,,one-boom,all,2,physicalMeasurement,time lat lon alt,True,
+batt_v_ss,battery_voltage_at_sample_start,Battery voltage (sample start),V,0,30,,one-boom,all,2,physicalMeasurement,time lat lon alt,True,
+fan_dc_u,fan_current,Fan current (upper boom),mA,0,200,,all,all,2,physicalMeasurement,time lat lon alt,True,
+fan_dc_l,fan_current,Fan current (lower boom),mA,0,200,,two-boom,all,2,physicalMeasurement,time lat lon alt,True,
+freq_vw,frequency_of_precipitation_wire_vibration,Frequency of vibrating wire in precipitation gauge,Hz,0,10000,precip_u,one-boom,all,,physicalMeasurement,time lat lon alt,True,
+t_log,temperature_of_logger,Logger temperature,degrees_C,-80,40,,one-boom,all,4,physicalMeasurement,time lat lon alt,True,LoggerTemperature(C)
+t_rad,temperature_of_radiation_sensor,Radiation sensor temperature,degrees_C,-80,40,t_surf dlr ulr,all,all,4,physicalMeasurement,time lat lon alt,True,
+p_i,air_pressure,Air pressure (instantaneous) minus 1000,hPa,-350,100,,all,TX,4,physicalMeasurement,time lat lon alt,True,For meteorological observations
+t_i,air_temperature,Air temperature (instantaneous),degrees_C,-80,40,,all,TX,4,physicalMeasurement,time lat lon alt,True,"PT100 temperature at boom, for meteorological observations"
+rh_i,relative_humidity,Relative humidity (instantaneous),%,0,150,rh_i_cor,all,TX,4,physicalMeasurement,time lat lon alt,True,For meteorological observations
+rh_i_cor,relative_humidity_corrected,Relative humidity (instantaneous) – corrected,%,0,100,,all,TX,4,modelResult,time lat lon alt,True,For meteorological observations
+wspd_i,wind_speed,Wind speed (instantaneous),m s-1,0,100,wdir_i wspd_x_i wspd_y_i,all,TX,4,physicalMeasurement,time lat lon alt,True,For meteorological observations
+wdir_i,wind_from_direction,Wind from direction (instantaneous),degrees,1,360,wspd_x_i wspd_y_i,all,TX,4,physicalMeasurement,time lat lon alt,True,For meteorological observations
+wspd_x_i,wind_speed_from_x_direction,Wind speed from x direction (instantaneous),m s-1,-100,100,wdir_i wspd_i,all,,4,modelResult,time lat lon alt,True,For meteorological observations
+wspd_y_i,wind_speed_from_y_direction,Wind speed from y direction (instantaneous),m s-1,-100,100,wdir_i wspd_i,all,,4,modelResult,time lat lon alt,True,For meteorological observations
+msg_i,message,Message string (instantaneous),-,,,,all,TX,,qualityInformation,time lat lon alt,True,For meteorological observations
+msg_lat,message_latitude,latitude from modem (email text),degrees_north,50,83,,all,all,6,coordinate,time lat lon alt,True,
+msg_lon,message_longitude,longitude from modem (email text),degrees_east,-72,13,,all,all,6,coordinate,time lat lon alt,True,


### PR DESCRIPTION
This addresses #68 and also comprehensively addresses the application of time shifting for any situation of file format and logger type. See the docstrings in `_addTimeShift` for further details.

I am not super familiar with going back and forth between xarray and pandas. You will see that I chose to do the work in `_addTimeShift` using pandas. Please double check my methods of returning back to xarray and re-assigning the attributes. It is pretty simple, but just not something I have done in the past.

Also, a general check of the logic depending on file format and logger type would be good. I embedded in the code with both tx v2 and tx v3 sample stations to confirm the use of `concat` and to confirm that the time-shifting is performing as intended.