### PR TITLE
persist uid in ini file

### DIFF
--- a/bin/getL0tx
+++ b/bin/getL0tx
@@ -97,6 +97,7 @@ if __name__ == '__main__':
  	#----------------------------------
 
  	# Get L0tx datalines from email transmissions
+    uid=last_uid # initialize using last_uid. If no messages, this will be written back to ini file.
     for uid, mail in getMail(mail_server, last_uid=last_uid):
         message = email.message_from_string(mail)
         

--- a/src/pypromice/tx.py
+++ b/src/pypromice/tx.py
@@ -751,7 +751,10 @@ def getMail(mail_server, last_uid=1):
     command = '(UID {}:*)'.format(last_uid)
     result, data = mail_server.uid('search', None, command)
     messages = data[0].split()
-    print('new UIDs: %s' %data[0].decode())
+    new_uids = data[0].decode()
+    # drop the last_uid (it has already been processed)
+    new_uids = new_uids.replace(str(last_uid), '')
+    print('new UIDs: %s' % new_uids)
 
     # Yield mails
     for message_uid in messages:


### PR DESCRIPTION
Modification to `getL0tx` will write the previous `last_uid` back to the ini file if no new messages are found.

The modification to `tx.py` is simply to improve the print statement. The `last_uid` should not be included in the list of new UIDs that is printed. As commented in the code, the search command always returns at least the most recent message, even if it has already been processed. So just remove from the print (it is also skipped in the processing).

Resolves: #76