### PR TITLE
WMO positions & variable skipping

### DIFF
--- a/bin/getBUFR
+++ b/bin/getBUFR
@@ -287,7 +287,7 @@ if __name__ == '__main__':
 	print('--------------------------------')
 	not_processed_wx_pos = set(failed_min_data_wx + failed_min_data_pos)
 	not_processed_count = len(skipped) + len(no_recent_data) + len(no_valid_data) + len(no_entry_latest_timestamps) + len(not_processed_wx_pos)
-	print('Finished processing {} of {} fpaths.'.format((len(fpaths) - not_processed_count),len(fpaths)))
+	print('BUFR exported for {} of {} fpaths.'.format((len(fpaths) - not_processed_count),len(fpaths)))
 	print('')
 	print('skipped: {}'.format(skipped))
 	print('no_recent_data: {}'.format(no_recent_data))

--- a/bin/getBUFR
+++ b/bin/getBUFR
@@ -117,9 +117,9 @@ if __name__ == '__main__':
 		stid = f[first_index+1:last_index]
 		# stid = f.split('/')[-1].split('.csv')[0][:-5]
 
+		print('####### Processing {} #######'.format(stid))
 		if ('Roof' not in f) and (stid not in to_skip):
 		# if ('v3' not in f) and ('Roof' not in f) and (stid not in to_skip):
-			print('####### Processing {} #######'.format(stid))
 			bufrname = stid + '.bufr'
 			print(f'Generating {bufrname} from {f}')
 
@@ -248,9 +248,9 @@ if __name__ == '__main__':
 
 					print(f'Successfully exported bufr file to {outFiles+bufrname}')
 				else:
-					print('Time checks failed for {}'.format(stid))
-					print('current:', current_timestamp)
-					print('latest:', latest_timestamp)
+					print('----> Time checks failed for {}'.format(stid))
+					print('      current:', current_timestamp)
+					print('       latest:', latest_timestamp)
 					no_recent_data.append(stid)
 					if args.positions is True:
 						positions = fetch_old_positions(df1, stid, args.time_limit, positions)
@@ -258,6 +258,7 @@ if __name__ == '__main__':
 				print('{} not found in latest_timestamps'.format(stid))
 				no_entry_latest_timestamps.append(stid)
 		else:
+			print('----> Skipping {} as per stid_to_skip config'.format(stid))
 			skipped.append(stid)
 			if args.positions is True:
 				# still will be useful to have all stations in AWS_station_location.csv,

--- a/src/pypromice/postprocess/csv2bufr.py
+++ b/src/pypromice/postprocess/csv2bufr.py
@@ -201,8 +201,9 @@ def setAWSvariables(ibufr, row, timestamp, stid):
     setBUFRvalue(ibufr, 'heightOfStationGroundAboveMeanSeaLevel', row['gps_alt_fit']) # also height and heightOfStation?
 
     # The ## in the codes_set() indicate the position in the BUFR for the parameter.
-    # e.g. #10#timePeriod will assign to the 10th occurence of "timePeriod".
-    # In the case of the synopMobil template, the 10th occurence is the wind speed section.
+    # e.g. #10#timePeriod will assign to the 10th occurence of "timePeriod", which corresponds
+    # to the wind speed section. Note that both the "synopMobil" and "synopLand" templates
+    # appear to have the same positions for all parameters that are set here.
     # View the output BUFR to see section keys with 'bufr_dump filename.bufr'.
     if math.isnan(row['wspd_i']) is False:
         #Set time significance (2=temporally averaged)

--- a/src/pypromice/postprocess/csv2bufr.py
+++ b/src/pypromice/postprocess/csv2bufr.py
@@ -483,11 +483,18 @@ def min_data_check(s, stid):
     min_data_wx_result = True
     min_data_pos_result = True
 
-    # Can use pd.isna() or math.isnan()
-    # Must have valid air temp and pressure
-    if (pd.isna(s['t_i']) is False) and (pd.isna(s['p_i']) is False):
-        pass
-    else:
+    # Can use pd.isna() or math.isnan() below...
+
+    # Always require valid air temp and valid pressure (both must be non-nan)
+    # if (pd.isna(s['t_i']) is False) and (pd.isna(s['p_i']) is False):
+    #     pass
+    # else:
+    #     print('----> Failed min_data_check for air temp and pressure!')
+    #     min_data_wx_result = False
+
+    # If both air temp and pressure are nan, do not submit.
+    # This will allow the case of having only one or the other.
+    if (pd.isna(s['t_i']) is True) and (pd.isna(s['p_i']) is True):
         print('----> Failed min_data_check for air temp and pressure!')
         min_data_wx_result = False
 

--- a/src/pypromice/postprocess/wmo_config.py
+++ b/src/pypromice/postprocess/wmo_config.py
@@ -16,8 +16,8 @@ stid_to_skip = { # All the following IDS will not be processed or submitted
     'not_registered': ['UWN'], # Need to register with Norwegion met
     'discontinued': ['CEN1','TAS_U','QAS_A','NUK_N','THU_U','JAR','SWC'],
     'no_instantaneous': ['ZAK_L','ZAK_U','KAN_B'], # currently not transmitting instantaneous values
-    'suspect_data': ['CP1','NAU'], # instantaneous data is suspect (CP1 & NAU, bad pressure)
-    'use_v3': ['KPC_L','NUK_U','ZAK_U','QAS_U'], # use v3 versions instead (but registered IDs will be non-v3)
+    'suspect_data': [], # instantaneous data is suspect
+    'use_v3': ['KPC_L','NUK_U','ZAK_U','QAS_U'], # use v3 versions instead (but registered IDs are non-v3 names)
     'v3_bad': ['KPC_Uv3','QAS_Lv3'] # KPC_Uv3 years are 2056, QAS_Lv3 new ablation sensor w/different txt fields?
     # Eventually, as we change all stations to v3, the use_v3 list should be empty (there will not be v3 and non-v3 stations operating together)
     # If your remove a station from 'v3_bad', then add it to 'use_v3' if both v2 and v3 stations still exist together
@@ -25,6 +25,14 @@ stid_to_skip = { # All the following IDS will not be processed or submitted
 # NOTE: Use both THU_L and THU_L2; use ONLY THU_U2, but register it as THU_U (this is dealt with in csv2bufr.py)
 # NOTE: JAR_O and SWC_O are used, but registered as JAR and SWC
 # NOTE: CEN2 data is registered as CEN
+
+vars_to_skip = { # skip specific variables for stations
+    # If a variable has known bad data, use this dict to skip the var
+    # Note that if the var is not reporting (NaN), then the entire station will be skipped as
+    # currently implemented in csv2bufr.min_data_check().
+    'CP1': ['p_i'],
+    'NAU': ['p_i']
+}
 
 ibufr_settings = {
     'mobile': { # mobile stations (on moving ice)


### PR DESCRIPTION
This PR has two updates:

1. Modify the `fetch_old_positions` function. This is used to grab positions for stations that were otherwise skipped or rejected from BUFR processing, so that we can still write their positions to the csv file (if available). A bug in the previous version of this was preventing some stations from flowing through the function.

2. Implement a method to skip specific variables for specific stations, using the config file. This was prompted by bad values for `p_i` that were identified by DMI for `CP1` and `NAU`.

As noted in the code, we need to be aware that if air temperature or pressure are not reporting at all (value is `NaN`), then the station is skipped entirely, as per `min_data_check()`. This new config setting therefore only applies to stations that are actually reporting a variable, but we have identified the variable as bad and wish to skip only that variable.

