### PR TITLE
Message grabber added

### DIFF
--- a/bin/getMsg
+++ b/bin/getMsg
@@ -26,24 +26,23 @@ if __name__ == '__main__':
     """Executed from the command line""" 
     args = parse_arguments()
 
-    # Set credential paths
+# Set credential paths
     accounts_file = args.account
     credentials_file = args.password 
         
-    # Set last aws uid path
+# Set last aws uid path
     last_uid = int(args.uid)
     
-    # Set output file directory
+# Set output file directory
     out_dir = args.outpath
-    
-    #-----------------------------------------
 
- 	# Define accounts and credentials ini file paths
+    
+# Define accounts and credentials ini file paths
     accounts_ini = ConfigParser()
     accounts_ini.readfp(open(accounts_file)) 	
     accounts_ini.read(credentials_file)    
     
- 	# Get credentials
+# Get credentials
     account = accounts_ini.get('aws', 'account')
     server = accounts_ini.get('aws', 'server')
     port = accounts_ini.getint('aws', 'port')    
@@ -52,9 +51,8 @@ if __name__ == '__main__':
         password = input('password for AWS email account: ')
     print('AWS data from server %s, account %s' %(server, account))
 
-    #-----------------------------------------
-
-    # Define last UID from file names
+    
+# Define last UID from file names
     if not os.path.exists(out_dir):
        os.mkdir(out_dir)
        if last_uid is None:
@@ -66,40 +64,36 @@ if __name__ == '__main__':
             last_uid = max(fn) 
         
     print('Fetching mail from uid %i' %last_uid)
+   
     
-    #-----------------------------------------
-    
- 	# Log in to email server
+# Log in to email server
     mail_server = imaplib.IMAP4_SSL(server, port)
     typ, accountDetails = mail_server.login(account, password) 	
     if typ != 'OK':
         print('Not able to sign in!')
         raise
 
- 	# Grab new emails
+# Grab new emails
     result, data = mail_server.select(mailbox='"[Gmail]/All Mail"', readonly=True)
     print('mailbox contains %s messages' %data[0])
 
-    #-----------------------------------------
 
- 	# Save mail to file
+# Save mail to file
     for uid, mail in getMail(mail_server, last_uid=last_uid):
         message = email.message_from_string(mail)
         outfile = str(message['subject'])+'_'+str(uid)+'.msg'
           
         with open(os.path.join(out_dir, outfile), 'w') as out:
              out.write(mail)
-        
-    #-----------------------------------------
 
- 	# Close mail server if open
+
+# Close mail server if open
     if 'mail_server' in locals():
         print(f'\nClosing {account}')
         mail_server.close()
         resp = mail_server.logout()
         assert resp[0].upper() == 'BYE'
 
-    #-----------------------------------------
     
     print('Finished')
     

--- a/bin/getMsg
+++ b/bin/getMsg
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+from argparse import ArgumentParser
+from configparser import ConfigParser
+import os, imaplib, email
+from glob import glob
+from pypromice.tx import getMail
+
+
+def parse_arguments():
+    parser = ArgumentParser(description="AWS message downloader")       
+    parser.add_argument('-a', '--account', default=None, type=str, 
+                        required=True, help='Email account .ini file')
+    parser.add_argument('-p', '--password', default=None, type=str, 
+                        required=True, help='Email credentials .ini file')                      
+    parser.add_argument('-o', '--outpath', default='.', type=str, 
+                        required=True, help='Path where to write output')    	
+    parser.add_argument('-u', '--uid', default=None, type=str, 
+                        required=True, help='Last uid, defined from files if not given')	
+    parser.add_argument('-m', '--mailbox', default='"[Gmail]/All Mail"', 
+                        type=str, required=True, help='Mailbox folder to collect messages from')        
+    args = parser.parse_args()
+    return args
+
+
+if __name__ == '__main__':
+    """Executed from the command line""" 
+    args = parse_arguments()
+
+    # Set credential paths
+    accounts_file = args.account
+    credentials_file = args.password 
+        
+    # Set last aws uid path
+    last_uid = int(args.uid)
+    
+    # Set output file directory
+    out_dir = args.outpath
+    
+    #-----------------------------------------
+
+ 	# Define accounts and credentials ini file paths
+    accounts_ini = ConfigParser()
+    accounts_ini.readfp(open(accounts_file)) 	
+    accounts_ini.read(credentials_file)    
+    
+ 	# Get credentials
+    account = accounts_ini.get('aws', 'account')
+    server = accounts_ini.get('aws', 'server')
+    port = accounts_ini.getint('aws', 'port')    
+    password = accounts_ini.get('aws', 'password')
+    if not password:
+        password = input('password for AWS email account: ')
+    print('AWS data from server %s, account %s' %(server, account))
+
+    #-----------------------------------------
+
+    # Define last UID from file names
+    if not os.path.exists(out_dir):
+       os.mkdir(out_dir)
+       if last_uid is None:
+            last_uid=0
+    else:
+        if last_uid is None:
+            fl = list(glob(os.path.join(out_dir,'*.msg')))
+            fn = [int(f.split('_')[-1].split('.')[0]) for f in fl]
+            last_uid = max(fn) 
+        
+    print('Fetching mail from uid %i' %last_uid)
+    
+    #-----------------------------------------
+    
+ 	# Log in to email server
+    mail_server = imaplib.IMAP4_SSL(server, port)
+    typ, accountDetails = mail_server.login(account, password) 	
+    if typ != 'OK':
+        print('Not able to sign in!')
+        raise
+
+ 	# Grab new emails
+    result, data = mail_server.select(mailbox='"[Gmail]/All Mail"', readonly=True)
+    print('mailbox contains %s messages' %data[0])
+
+    #-----------------------------------------
+
+ 	# Save mail to file
+    for uid, mail in getMail(mail_server, last_uid=last_uid):
+        message = email.message_from_string(mail)
+        outfile = str(message['subject'])+'_'+str(uid)+'.msg'
+          
+        with open(os.path.join(out_dir, outfile), 'w') as out:
+             out.write(mail)
+        
+    #-----------------------------------------
+
+ 	# Close mail server if open
+    if 'mail_server' in locals():
+        print(f'\nClosing {account}')
+        mail_server.close()
+        resp = mail_server.logout()
+        assert resp[0].upper() == 'BYE'
+
+    #-----------------------------------------
+    
+    print('Finished')
+    
+else:
+    """Executed on import"""
+    pass

--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,5 @@ setuptools.setup(
     packages=setuptools.find_packages(where="src"),
     python_requires=">=3.6",
     install_requires=['numpy', 'pandas', 'xarray', 'toml', 'scipy'],
-    scripts=['bin/getData', 'bin/getL0tx', 'bin/getL3', 'bin/joinL3', 'bin/getWatsontx', 'bin/getBUFR'],
+    scripts=['bin/getData', 'bin/getL0tx', 'bin/getL3', 'bin/joinL3', 'bin/getWatsontx', 'bin/getBUFR', 'bin/getMsg'],
 )

--- a/src/pypromice/tx.py
+++ b/src/pypromice/tx.py
@@ -754,7 +754,8 @@ def getMail(mail_server, last_uid=1):
     new_uids = data[0].decode()
     # drop the last_uid (it has already been processed)
     new_uids = new_uids.replace(str(last_uid), '')
-    print('new UIDs: %s' % new_uids)
+    print('Newest UID: %s' % new_uids.split(' ')[-1])
+    # print('new UIDs: %s' % new_uids)
 
     # Yield mails
     for message_uid in messages:


### PR DESCRIPTION
`bin/getMsg` function added for grabbing and saving transmission messages. It is intended for this to work alongside the current operational processing to back-up transmission messages in a local file space (rather than relying on remote Gmail storage).

I also replaced a line in `tx.getMail` to only print a statement of the newest message `uid` rather than printing them all - it can get pretty lengthy otherwise.