### PR TITLE
Version change

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,23 +5,22 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="pypromice",
-    version="0.0.1",
-    author="Penelope How",
-    author_email="pho@geus.dk",
-    description="PROMICE data processing toolbox",
+    version="2.0.0",
+    author="GEUS Glaciology and Climate",
+    description="PROMICE/GC-Net data processing toolbox",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/GEUS-Glaciology-and-Climate/PROMICE-AWS-processing",
     project_urls={
-        "Bug Tracker": "https://github.com/GEUS-Glaciology-and-Climate/PROMICE-AWS-processing/issues",
-        "Documentation": "https://github.com/GEUS-Glaciology-and-Climate/PROMICE-AWS-processing",
-    "Source Code": "https://github.com/GEUS-Glaciology-and-Climate/PROMICE-AWS-processing"
+        "Bug Tracker": "https://github.com/GEUS-Glaciology-and-Climate/pypromice/issues",
+        "Documentation": "https://pypromice.readthedocs.io",
+    "Source Code": "https://github.com/GEUS-Glaciology-and-Climate/pypromice"
     },
     keywords="promice gc-net aws climate glaciology greenland geus",
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
-        "Development Status :: 4 - Beta",
+        "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Science/Research",
         "Natural Language :: English",
         "Topic :: Scientific/Engineering",
@@ -30,7 +29,7 @@ setuptools.setup(
     package_dir={"": "src"},
     include_package_data = True,
     packages=setuptools.find_packages(where="src"),
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     install_requires=['numpy', 'pandas', 'xarray', 'toml', 'scipy'],
     scripts=['bin/getData', 'bin/getL0tx', 'bin/getL3', 'bin/joinL3', 'bin/getWatsontx', 'bin/getBUFR', 'bin/getMsg'],
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="pypromice",
-    version="2.0.0",
+    version="1.0.0",
     author="GEUS Glaciology and Climate",
     description="PROMICE/GC-Net data processing toolbox",
     long_description=long_description,


### PR DESCRIPTION
Because we are releasing a new Dataverse AWS dataset, I think the pypromice version needs to move up also (as we will also publish pypromice to Dataverse again). 

I explained in #79 that keeping consistent version naming conventions between Github, pip and Dataverse is tricky.

>At the moment, our [pypromice releases](https://github.com/GEUS-Glaciology-and-Climate/pypromice/releases) on GitHub are mismatched with our Dataverse versioning (found here: [https://doi.org/10.22008/FK2/IPOHT5](https://doi.org/10.22008/FK2/IPOHT5)). This is because Dataverse versioning is fixed to single digit naming conventions `V1, V2, V3...`. For example, the most recent pypromice release on GitHub is `v0.0.1`, however on Dataverse the same release is called `V1`. **This presents ambiguity.**

>**I propose that we coordinate pypromice versions across GitHub, pip and Dataverse**, whereby all three platforms have the same major versions `v1, v2, v3...`, but only GitHub and pip host sub-releases `v1.1.0, v1.2.0, v1.3.0...`
>- Major releases should be published when pypromice has significant changes that alter PROMICE one-boom and/or two-boom dataset releases
>- Sub-releases should be published when pypromice has changes to improve usability, efficiency, structuring etc., but do not significantly affect PROMICE one-boom and two-boom processing and datasets

So, if we go with this, then pypromice will be `V2` when we publish it to Dataverse alongside the AWS data release. And therefore the new release on Github (in `setup.py`) needs to also be `v2.0.0`.