### PR TITLE
Deprecated readfp

### DIFF
--- a/bin/getL0tx
+++ b/bin/getL0tx
@@ -65,8 +65,8 @@ if __name__ == '__main__':
 
  	# Define accounts and credentials ini file paths
     accounts_ini = ConfigParser()
-    accounts_ini.readfp(open(accounts_file)) 	
-    accounts_ini.read(credentials_file) 
+    accounts_ini.read_file(open(accounts_file))
+    accounts_ini.read(credentials_file)
 
  	# Get last email uid
     with open(uid_file, 'r') as last_uid_f:

--- a/bin/getMsg
+++ b/bin/getMsg
@@ -43,8 +43,8 @@ if __name__ == '__main__':
     
 # Define accounts and credentials ini file paths
     accounts_ini = ConfigParser()
-    accounts_ini.readfp(open(accounts_file)) 	
-    accounts_ini.read(credentials_file)    
+    accounts_ini.read_file(open(accounts_file))
+    accounts_ini.read(credentials_file)
     
 # Get credentials
     account = accounts_ini.get('aws', 'account')

--- a/bin/getMsg
+++ b/bin/getMsg
@@ -26,27 +26,27 @@ if __name__ == '__main__':
     """Executed from the command line""" 
     args = parse_arguments()
 
-# Set credential paths
+    # Set credential paths
     accounts_file = args.account
     credentials_file = args.password 
         
-# Set last aws uid path
+    # Set last aws uid path
     if args.uid is not None:
         last_uid = int(args.uid)
     else:
         last_uid=None
           
     
-# Set output file directory
+    # Set output file directory
     out_dir = args.outpath
 
     
-# Define accounts and credentials ini file paths
+    # Define accounts and credentials ini file paths
     accounts_ini = ConfigParser()
     accounts_ini.read_file(open(accounts_file))
     accounts_ini.read(credentials_file)
     
-# Get credentials
+    # Get credentials
     account = accounts_ini.get('aws', 'account')
     server = accounts_ini.get('aws', 'server')
     port = accounts_ini.getint('aws', 'port')    
@@ -56,7 +56,7 @@ if __name__ == '__main__':
     print('AWS data from server %s, account %s' %(server, account))
 
     
-# Define last UID from file names
+    # Define last UID from file names
     if not os.path.exists(out_dir):
        os.mkdir(out_dir)
        if last_uid is None:
@@ -70,19 +70,19 @@ if __name__ == '__main__':
     print('Fetching mail from uid %i' %last_uid)
    
     
-# Log in to email server
+    # Log in to email server
     mail_server = imaplib.IMAP4_SSL(server, port)
     typ, accountDetails = mail_server.login(account, password) 	
     if typ != 'OK':
         print('Not able to sign in!')
         raise
 
-# Grab new emails
+    # Grab new emails
     result, data = mail_server.select(mailbox='"[Gmail]/All Mail"', readonly=True)
     print('mailbox contains %s messages' %data[0])
 
 
-# Save mail to file
+    # Save mail to file
     for uid, mail in getMail(mail_server, last_uid=last_uid):
         message = email.message_from_string(mail)
         outfile = str(message['subject'])+'_'+str(uid)+'.msg'
@@ -91,7 +91,7 @@ if __name__ == '__main__':
              out.write(mail)
 
 
-# Close mail server if open
+    # Close mail server if open
     if 'mail_server' in locals():
         print(f'\nClosing {account}')
         mail_server.close()

--- a/bin/getWatsontx
+++ b/bin/getWatsontx
@@ -59,8 +59,8 @@ if __name__ == '__main__':
     
     # Define accounts and credentials ini file paths
     accounts_ini = ConfigParser()
-    accounts_ini.readfp(open(accounts_file))
-    accounts_ini.read(credentials_file) 
+    accounts_ini.read_file(open(accounts_file))
+    accounts_ini.read(credentials_file)
                  
     # Get credentials
     account = accounts_ini.get('aws', 'account')


### PR DESCRIPTION
Quick PR to address the following deprecation warning:

```
DeprecationWarning: This method will be removed in future versions.  Use 'parser.read_file()' instead.
  accounts_ini.readfp(open(accounts_file))
```
Also corrected my previous bad comment re: indentation since I had the file open!
