### PR TITLE
Update doi

### DIFF
--- a/.github/workflows/dataverse_workflow.yml
+++ b/.github/workflows/dataverse_workflow.yml
@@ -13,6 +13,6 @@ jobs:
         with:
           DATAVERSE_TOKEN: ${{secrets.DATAVERSE_TOKEN}}
           DATAVERSE_SERVER: https://dataverse.geus.dk
-          DATAVERSE_DATASET_DOI: doi:10.22008/FK2/IPOHT5
+          DATAVERSE_DATASET_DOI: doi:10.22008/FK2/3TSBF0
           DELETE: True
           PUBLSH: False

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ If you intend to use PROMICE AWS data and/or pypromice in your work, please cite
 
 **Fausto, R.S., van As, D., Mankoff, K.D., Vandecrux, B., Citterio, M., Ahlstrøm, A.P., Andersen, S.B., Colgan, W., Karlsson, N.B., Kjeldsen, K.K., Korsgaard, N.J., Larsen, S.H., Nielsen, S., Pedersen, A.Ø., Shields, C.L., Solgaard, A.M., and Box, J.E. (2021) Programme for Monitoring of the Greenland Ice Sheet (PROMICE) automatic weather station data, Earth Syst. Sci. Data, 13, 3819–3845, [https://doi.org/10.5194/essd-13-3819-2021](https://doi.org/10.5194/essd-13-3819-2021)**
 
-**How, P., Wright, P.J., Mankoff, K., Vandecrux, B. (2022) pypromice, GEUS Dataverse, [https://doi.org/10.22008/FK2/3TSBF0](https://doi.org/10.22008/FK2/3TSBF0)** 
+**How, P., Wright, P.J., Mankoff, K., Vandecrux, B. (2023) pypromice, GEUS Dataverse, [https://doi.org/10.22008/FK2/3TSBF0](https://doi.org/10.22008/FK2/3TSBF0)** 
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # pypromice
-[![](<https://img.shields.io/badge/Dataverse DOI-10.22008/FK2/IPOHT5-orange>)](https://www.doi.org/10.22008/FK2/IPOHT5) [![Documentation Status](https://readthedocs.org/projects/pypromice/badge/?version=latest)](https://pypromice.readthedocs.io/en/latest/?badge=latest)
+[![](<https://img.shields.io/badge/Dataverse DOI-10.22008/FK2/3TSBF0-orange>)](https://www.doi.org/10.22008/FK2/3TSBF0) [![Documentation Status](https://readthedocs.org/projects/pypromice/badge/?version=latest)](https://pypromice.readthedocs.io/en/latest/?badge=latest)
  
 pypromice is designed for processing and handling [PROMICE](https://promice.dk) automated weather station (AWS) data.
 
@@ -9,7 +9,7 @@ If you intend to use PROMICE AWS data and/or pypromice in your work, please cite
 
 **Fausto, R.S., van As, D., Mankoff, K.D., Vandecrux, B., Citterio, M., Ahlstrøm, A.P., Andersen, S.B., Colgan, W., Karlsson, N.B., Kjeldsen, K.K., Korsgaard, N.J., Larsen, S.H., Nielsen, S., Pedersen, A.Ø., Shields, C.L., Solgaard, A.M., and Box, J.E. (2021) Programme for Monitoring of the Greenland Ice Sheet (PROMICE) automatic weather station data, Earth Syst. Sci. Data, 13, 3819–3845, [https://doi.org/10.5194/essd-13-3819-2021](https://doi.org/10.5194/essd-13-3819-2021)**
 
-**How, P., Mankoff, K., Wright, P.J., Vandecrux, B. (2022) pypromice, GEUS Dataverse,  [https://doi.org/10.22008/FK2/IPOHT5](https://doi.org/10.22008/FK2/IPOHT5)** 
+**How, P., Wright, P.J., Mankoff, K., Vandecrux, B. (2022) pypromice, GEUS Dataverse, [https://doi.org/10.22008/FK2/3TSBF0](https://doi.org/10.22008/FK2/3TSBF0)** 
 
 
 ## Installation

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,7 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('../src'))
 sys.path.insert(0, os.path.abspath('../src/pypromice'))
+sys.path.insert(0, os.path.abspath('../src/pypromice/postprocess'))
 
 # -- Project information -----------------------------------------------------
 
@@ -23,7 +24,7 @@ copyright = '2022, GEUS Glaciology and Climate'
 author = 'GEUS Glaciology and Climate'
 
 # The full version, including alpha/beta/rc tags
-release = '0.0.1'
+release = '1.0.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ sys.path.insert(0, os.path.abspath('../src/pypromice/postprocess'))
 # -- Project information -----------------------------------------------------
 
 project = 'pypromice'
-copyright = '2022, GEUS Glaciology and Climate'
+copyright = '2023, GEUS Glaciology and Climate'
 author = 'GEUS Glaciology and Climate'
 
 # The full version, including alpha/beta/rc tags

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ If you intend to use PROMICE AWS data and/or pypromice in your work, please cite
 
 Fausto, R.S., van As, D., Mankoff, K.D., Vandecrux, B., Citterio, M., Ahlstrøm, A.P., Andersen, S.B., Colgan, W., Karlsson, N.B., Kjeldsen, K.K., Korsgaard, N.J., Larsen, S.H., Nielsen, S., Pedersen, A.Ø., Shields, C.L., Solgaard, A.M., and Box, J.E. (2021) Programme for Monitoring of the Greenland Ice Sheet (PROMICE) automatic weather station data, Earth Syst. Sci. Data, 13, 3819–3845, https://doi.org/10.5194/essd-13-3819-2021
 
-How, P., Mankoff, K., Wright, P.J., Vandecrux, B. (2022) pypromice, GEUS Dataverse, https://doi.org/10.22008/FK2/IPOHT5
+How, P., Mankoff, K., Wright, P.J., Vandecrux, B. (2022) pypromice, GEUS Dataverse, https://doi.org/10.22008/FK2/3TSBF0
 
 .. _pypromice: https://github.com/GEUS-Glaciology-and-Climate/pypromice
 .. _PROMICE: https://promice.dk

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ If you intend to use PROMICE AWS data and/or pypromice in your work, please cite
 
 Fausto, R.S., van As, D., Mankoff, K.D., Vandecrux, B., Citterio, M., Ahlstrøm, A.P., Andersen, S.B., Colgan, W., Karlsson, N.B., Kjeldsen, K.K., Korsgaard, N.J., Larsen, S.H., Nielsen, S., Pedersen, A.Ø., Shields, C.L., Solgaard, A.M., and Box, J.E. (2021) Programme for Monitoring of the Greenland Ice Sheet (PROMICE) automatic weather station data, Earth Syst. Sci. Data, 13, 3819–3845, https://doi.org/10.5194/essd-13-3819-2021
 
-How, P., Mankoff, K., Wright, P.J., Vandecrux, B. (2022) pypromice, GEUS Dataverse, https://doi.org/10.22008/FK2/3TSBF0
+How, P., Wright, P.J., Mankoff, K., Vandecrux, B. (2022) pypromice, GEUS Dataverse, https://doi.org/10.22008/FK2/3TSBF0
 
 .. _pypromice: https://github.com/GEUS-Glaciology-and-Climate/pypromice
 .. _PROMICE: https://promice.dk

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ If you intend to use PROMICE AWS data and/or pypromice in your work, please cite
 
 Fausto, R.S., van As, D., Mankoff, K.D., Vandecrux, B., Citterio, M., Ahlstrøm, A.P., Andersen, S.B., Colgan, W., Karlsson, N.B., Kjeldsen, K.K., Korsgaard, N.J., Larsen, S.H., Nielsen, S., Pedersen, A.Ø., Shields, C.L., Solgaard, A.M., and Box, J.E. (2021) Programme for Monitoring of the Greenland Ice Sheet (PROMICE) automatic weather station data, Earth Syst. Sci. Data, 13, 3819–3845, https://doi.org/10.5194/essd-13-3819-2021
 
-How, P., Wright, P.J., Mankoff, K., Vandecrux, B. (2022) pypromice, GEUS Dataverse, https://doi.org/10.22008/FK2/3TSBF0
+How, P., Wright, P.J., Mankoff, K., Vandecrux, B. (2023) pypromice, GEUS Dataverse, https://doi.org/10.22008/FK2/3TSBF0
 
 .. _pypromice: https://github.com/GEUS-Glaciology-and-Climate/pypromice
 .. _PROMICE: https://promice.dk

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,5 +3,6 @@ datetime
 eccodes
 numpy
 pandas
+sklearn
 toml
 xarray


### PR DESCRIPTION
- DOI updated in accordance with [new pypromice release on Dataverse](https://doi.org/10.22008/FK2/3TSBF0)
- New requirements and path added to `docs` in order to map `postprocess` module to readthedocs