### PR TITLE
Automated data_url.csv updater in Github Action

### DIFF
--- a/.github/workflows/url_update.yml
+++ b/.github/workflows/url_update.yml
@@ -38,9 +38,12 @@ jobs:
           CI_COMMIT_AUTHOR: PennyHow
           CI_COMMIT_EMAIL: pho@geus.dk
         run: |
-          cd $GITHUB_WORKSPACE
-          git config --global user.name "${{ env.CI_COMMIT_AUTHOR }}"
-          git config --global user.email "${{ env.CI_COMMIT_EMAIL }}"
-          git add src/pypromice/data_urls.csv
-          git commit -m "${{ env.CI_COMMIT_MSG }}"
-          git push
+          cd $GITHUB_WORKSPACE/pypromice
+          if test `find "src/data_urls.csv" -mmin +1`
+          then 
+            git config --global user.name "${{ env.CI_COMMIT_AUTHOR }}"
+            git config --global user.email "${{ env.CI_COMMIT_EMAIL }}"
+            git add src/pypromice/data_urls.csv
+            git commit -m "${{ env.CI_COMMIT_MSG }}"
+            git push
+          fi

--- a/.github/workflows/url_update.yml
+++ b/.github/workflows/url_update.yml
@@ -27,8 +27,8 @@ jobs:
           TWO_BOOM_DOI: doi:10.22008/FK2/IW73UU
         shell: bash
         run: |
-          python3 $GITHUB_WORKSPACE/pypromice/bin/updateURL -d ${{ env.ONE_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
-          python3 $GITHUB_WORKSPACE/pypromice/bin/updateURL -d ${{ env.TWO_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
+          python3 $GITHUB_WORKSPACE/bin/updateURL -d ${{ env.ONE_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
+          python3 $GITHUB_WORKSPACE/bin/updateURL -d ${{ env.TWO_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
       - name: Push changes to branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -36,7 +36,7 @@ jobs:
           CI_COMMIT_AUTHOR: PennyHow
           CI_COMMIT_EMAIL: pho@geus.dk
         run: |
-          cd $GITHUB_WORKSPACE/pypromice
+          cd $GITHUB_WORKSPACE
           git config --global user.name "${{ env.CI_COMMIT_AUTHOR }}"
           git config --global user.email "${{ env.CI_COMMIT_EMAIL }}"
           git add src/pypromice/data_urls.csv

--- a/.github/workflows/url_update.yml
+++ b/.github/workflows/url_update.yml
@@ -25,9 +25,10 @@ jobs:
           DATAVERSE_TOKEN: ${{ secrets.DATAVERSE_TOKEN }}
           ONE_BOOM_DOI: doi:10.22008/FK2/3TSBF0
           TWO_BOOM_DOI: doi:10.22008/FK2/IW73UU
+        shell: bash
         run: |
-          python3 updateURLs -d ${{ env.ONE_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
-          python3 updateURLs -d ${{ env.TWO_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
+          updateURLs -d ${{ env.ONE_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
+          updateURLs -d ${{ env.TWO_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
       - name: Push changes to branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/url_update.yml
+++ b/.github/workflows/url_update.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
         with:
-          ref: url-update-2
+          ref: main
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Python
         uses: actions/setup-python@v2

--- a/.github/workflows/url_update.yml
+++ b/.github/workflows/url_update.yml
@@ -30,6 +30,8 @@ jobs:
           python3 $GITHUB_WORKSPACE/bin/updateURL -f $GITHUB_WORKSPACE/src/pypromice/data_urls.csv -o $GITHUB_WORKSPACE/src/pypromice/data_urls.csv -d ${{ env.ONE_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
           python3 $GITHUB_WORKSPACE/bin/updateURL -f $GITHUB_WORKSPACE/src/pypromice/data_urls.csv -o $GITHUB_WORKSPACE/src/pypromice/data_urls.csv -d ${{ env.TWO_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
       - name: Push changes to branch
+        if: 
+          test `find "$GITHUB_WORKSPACE/pypromice/src/data_urls.csv" -mmin +1`
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CI_COMMIT_MSG: URL update from Github Action

--- a/.github/workflows/url_update.yml
+++ b/.github/workflows/url_update.yml
@@ -36,8 +36,8 @@ jobs:
           CI_COMMIT_AUTHOR: PennyHow
           CI_COMMIT_EMAIL: pho@geus.dk
         run: |
-          cd $GITHUB_WORKSPACE/pypromice
-          if test `find "src/data_urls.csv" -mmin +1`
+          cd $GITHUB_WORKSPACE
+          if test `find "src/pypromice/data_urls.csv" -mmin +1`
           then 
             git config --global user.name "${{ env.CI_COMMIT_AUTHOR }}"
             git config --global user.email "${{ env.CI_COMMIT_EMAIL }}"

--- a/.github/workflows/url_update.yml
+++ b/.github/workflows/url_update.yml
@@ -10,6 +10,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: url-update-2
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Python
         uses: actions/setup-python@v2
         with:
@@ -26,8 +27,8 @@ jobs:
           TWO_BOOM_DOI: doi:10.22008/FK2/IW73UU
         shell: bash
         run: |
-          python3 repo/bin/updateURL -d ${{ env.ONE_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
-          python3 repo/bin/updateURL -d ${{ env.TWO_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
+          python3 pypromice/bin/updateURL -d ${{ env.ONE_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
+          python3 pypromice/bin/updateURL -d ${{ env.TWO_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
       - name: Push changes to branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/url_update.yml
+++ b/.github/workflows/url_update.yml
@@ -37,5 +37,5 @@ jobs:
           git config --global user.name "${{ env.CI_COMMIT_AUTHOR }}"
           git config --global user.email "${{ env.CI_COMMIT_EMAIL }}"
           git add src/pypromice/data_urls.csv
-          git commit -m "${{ CI_COMMIT_MSG }}"
+          git commit -m "${{ env.CI_COMMIT_MSG }}"
           git push

--- a/.github/workflows/url_update.yml
+++ b/.github/workflows/url_update.yml
@@ -18,7 +18,6 @@ jobs:
         shell: bash
         run: |
           python -m pip install --upgrade pip
-          pip install --upgrade git+http://github.com/GEUS-Glaciology-and-Climate/pypromice.git@url-update-2
           pip install pandas==1.5.0 pyDataverse==0.3.1            
       - name: Update AWS URLs
         env:
@@ -27,8 +26,8 @@ jobs:
           TWO_BOOM_DOI: doi:10.22008/FK2/IW73UU
         shell: bash
         run: |
-          updateURL -d ${{ env.ONE_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
-          updateURL -d ${{ env.TWO_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
+          python3 repo/bin/updateURL -d ${{ env.ONE_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
+          python3 repo/bin/updateURL -d ${{ env.TWO_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
       - name: Push changes to branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/url_update.yml
+++ b/.github/workflows/url_update.yml
@@ -1,0 +1,41 @@
+on:
+  push:
+  workflow_dispatch:
+  
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          ref: url-fix
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      - name: Install dependencies
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          pip install pandas==1.5.0 pyDataverse==0.3.1            
+      - name: Update AWS URLs
+        env:
+          DATAVERSE_TOKEN: ${{ secrets.DATAVERSE_TOKEN }}
+          ONE_BOOM_DOI: doi:10.22008/FK2/3TSBF0
+          TWO_BOOM_DOI: doi:10.22008/FK2/IW73UU
+        run: |
+          python3 bin/updateURLs -d ${{ env.ONE_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
+          python3 bin/updateURLs -d ${{ env.TWO_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
+      - name: Push changes to branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CI_COMMIT_MSG: URL update from Github Action
+          CI_COMMIT_AUTHOR: PennyHow
+          CI_COMMIT_EMAIL: pho@geus.dk
+        run: |
+          git config --global user.name "${{ env.CI_COMMIT_AUTHOR }}"
+          git config --global user.email "${{ env.CI_COMMIT_EMAIL }}"
+          git add src/pypromice/data_urls.csv
+          git commit -m "${{ CI_COMMIT_MSG }}"
+          git push

--- a/.github/workflows/url_update.yml
+++ b/.github/workflows/url_update.yml
@@ -27,8 +27,8 @@ jobs:
           TWO_BOOM_DOI: doi:10.22008/FK2/IW73UU
         shell: bash
         run: |
-          python3 updateURL -d ${{ env.ONE_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
-          python3 updateURL -d ${{ env.TWO_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
+          updateURL -d ${{ env.ONE_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
+          updateURL -d ${{ env.TWO_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
       - name: Push changes to branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/url_update.yml
+++ b/.github/workflows/url_update.yml
@@ -18,6 +18,7 @@ jobs:
         shell: bash
         run: |
           python -m pip install --upgrade pip
+          pip install --upgrade git+http://github.com/GEUS-Glaciology-and-Climate/pypromice.git
           pip install pandas==1.5.0 pyDataverse==0.3.1            
       - name: Update AWS URLs
         env:
@@ -25,8 +26,8 @@ jobs:
           ONE_BOOM_DOI: doi:10.22008/FK2/3TSBF0
           TWO_BOOM_DOI: doi:10.22008/FK2/IW73UU
         run: |
-          python3 bin/updateURLs -d ${{ env.ONE_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
-          python3 bin/updateURLs -d ${{ env.TWO_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
+          python3 updateURLs -d ${{ env.ONE_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
+          python3 updateURLs -d ${{ env.TWO_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
       - name: Push changes to branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/url_update.yml
+++ b/.github/workflows/url_update.yml
@@ -27,8 +27,8 @@ jobs:
           TWO_BOOM_DOI: doi:10.22008/FK2/IW73UU
         shell: bash
         run: |
-          updateURLs -d ${{ env.ONE_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
-          updateURLs -d ${{ env.TWO_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
+          python3 repo/bin/updateURLs -d ${{ env.ONE_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
+          python3 repo/bin/updateURLs -d ${{ env.TWO_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
       - name: Push changes to branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/url_update.yml
+++ b/.github/workflows/url_update.yml
@@ -18,7 +18,7 @@ jobs:
         shell: bash
         run: |
           python -m pip install --upgrade pip
-          pip install --upgrade git+http://github.com/GEUS-Glaciology-and-Climate/pypromice.git
+          pip install --upgrade git+http://github.com/GEUS-Glaciology-and-Climate/pypromice.git@url-update-2
           pip install pandas==1.5.0 pyDataverse==0.3.1            
       - name: Update AWS URLs
         env:
@@ -27,8 +27,8 @@ jobs:
           TWO_BOOM_DOI: doi:10.22008/FK2/IW73UU
         shell: bash
         run: |
-          python3 repo/bin/updateURLs -d ${{ env.ONE_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
-          python3 repo/bin/updateURLs -d ${{ env.TWO_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
+          python3 updateURL -d ${{ env.ONE_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
+          python3 updateURL -d ${{ env.TWO_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
       - name: Push changes to branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/url_update.yml
+++ b/.github/workflows/url_update.yml
@@ -30,8 +30,6 @@ jobs:
           python3 $GITHUB_WORKSPACE/bin/updateURL -f $GITHUB_WORKSPACE/src/pypromice/data_urls.csv -o $GITHUB_WORKSPACE/src/pypromice/data_urls.csv -d ${{ env.ONE_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
           python3 $GITHUB_WORKSPACE/bin/updateURL -f $GITHUB_WORKSPACE/src/pypromice/data_urls.csv -o $GITHUB_WORKSPACE/src/pypromice/data_urls.csv -d ${{ env.TWO_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
       - name: Push changes to branch
-        if: 
-          test `find "$GITHUB_WORKSPACE/pypromice/src/data_urls.csv" -mmin +1`
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CI_COMMIT_MSG: URL update from Github Action

--- a/.github/workflows/url_update.yml
+++ b/.github/workflows/url_update.yml
@@ -27,8 +27,8 @@ jobs:
           TWO_BOOM_DOI: doi:10.22008/FK2/IW73UU
         shell: bash
         run: |
-          python3 $GITHUB_WORKSPACE/bin/updateURL -d ${{ env.ONE_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
-          python3 $GITHUB_WORKSPACE/bin/updateURL -d ${{ env.TWO_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
+          python3 $GITHUB_WORKSPACE/bin/updateURL -f $GITHUB_WORKSPACE/src/pypromice/data_urls.csv -o $GITHUB_WORKSPACE/src/pypromice/data_urls.csv -d ${{ env.ONE_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
+          python3 $GITHUB_WORKSPACE/bin/updateURL -f $GITHUB_WORKSPACE/src/pypromice/data_urls.csv -o $GITHUB_WORKSPACE/src/pypromice/data_urls.csv -d ${{ env.TWO_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
       - name: Push changes to branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/url_update.yml
+++ b/.github/workflows/url_update.yml
@@ -1,4 +1,6 @@
 on:
+  schedule:
+    - cron: "0 12 1 * *"
   push:
   workflow_dispatch:
   
@@ -9,7 +11,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
         with:
-          ref: main
+          ref: url-update-2
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Python
         uses: actions/setup-python@v2

--- a/.github/workflows/url_update.yml
+++ b/.github/workflows/url_update.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
         with:
-          ref: url-fix
+          ref: url-update-2
       - name: Install Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/url_update.yml
+++ b/.github/workflows/url_update.yml
@@ -11,7 +11,6 @@ jobs:
         with:
           ref: url-update-2
           token: ${{ secrets.GITHUB_TOKEN }}
-          path: repo
       - name: Install Python
         uses: actions/setup-python@v2
         with:
@@ -28,8 +27,8 @@ jobs:
           TWO_BOOM_DOI: doi:10.22008/FK2/IW73UU
         shell: bash
         run: |
-          python3 pypromice/bin/updateURL -d ${{ env.ONE_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
-          python3 pypromice/bin/updateURL -d ${{ env.TWO_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
+          python3 $GITHUB_WORKSPACE/pypromice/bin/updateURL -d ${{ env.ONE_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
+          python3 $GITHUB_WORKSPACE/pypromice/bin/updateURL -d ${{ env.TWO_BOOM_DOI }} -t ${{ env.DATAVERSE_TOKEN }}
       - name: Push changes to branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -37,6 +36,7 @@ jobs:
           CI_COMMIT_AUTHOR: PennyHow
           CI_COMMIT_EMAIL: pho@geus.dk
         run: |
+          cd $GITHUB_WORKSPACE/pypromice
           git config --global user.name "${{ env.CI_COMMIT_AUTHOR }}"
           git config --global user.email "${{ env.CI_COMMIT_EMAIL }}"
           git add src/pypromice/data_urls.csv

--- a/.github/workflows/url_update.yml
+++ b/.github/workflows/url_update.yml
@@ -11,6 +11,7 @@ jobs:
         with:
           ref: url-update-2
           token: ${{ secrets.GITHUB_TOKEN }}
+          path: repo
       - name: Install Python
         uses: actions/setup-python@v2
         with:

--- a/bin/updateURL
+++ b/bin/updateURL
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Tue Feb  7 09:24:32 2023
+
+URL updater for retrieving PROMICE and GC-Net AWS datasets
+
+@author: Penelope How, pho@geus.dk
+"""
+
+import pandas as pd
+from argparse import ArgumentParser
+from pyDataverse.api import NativeApi
+
+def parse_arguments():
+    parser = ArgumentParser(description="Update URLs in given file if they " \
+                            "mismatch URLs in Dataverse DOI entry")
+        
+    parser.add_argument('-f', '--infile', type=str, required=False,
+                        default='src/pypromice/data_urls.csv',                         
+                        help='Path to data_urls.csv file')
+    
+    parser.add_argument('-d', '--doi', type=str, required=True, 
+                        help='DOI of Dataverse entry')
+    
+    parser.add_argument('-u', '--url', type=str, required=False, 
+                        default='https://dataverse.geus.dk', 
+                        help='Base URL of Dataverse installation')
+    
+    parser.add_argument('-t', '--token', type=str, required=False,
+                        default=None,
+                        help='API token of Dataverse installation')
+    
+    parser.add_argument('-o', '--outfile', type=str, required=False,
+                        default='src/pypromice/data_urls.csv', 
+                        help='Output .csv file path for updated URLs')
+    args = parser.parse_args()
+    return args
+
+def getDataDOIs(doi, base_url, api_token=None):
+    '''Get list of data file DOI dictionaries from a given Dataverse DOI'''
+    api = NativeApi(base_url, api_token)        
+    dataset = api.get_dataset(doi)
+    files_list = dataset.json()['data']['latestVersion']['files']
+    datav=[]
+    for f in files_list: 
+        new={}
+        for k,v in f.items():
+            if k=='label':
+                new['name']= v
+            elif k=='dataFile':
+                new['doi']= f[k]['persistentId']
+                new['link'] = DOI2URL(f[k]['persistentId'])
+        datav.append(new)    
+    return datav
+
+def DOI2URL(doi, 
+            url='https://dataverse.geus.dk/api/access/datafile/:persistentId?persistentId='):
+    '''Translate DOI to URL download link'''
+    return ''.join([url, doi])
+
+def openDataURLs(infile):
+    '''Return DataFrame of Data URLs from file'''
+    return pd.read_csv(infile, index_col=0)
+
+def match(u1, u2):
+    '''Match two strings and return bool'''
+    if u1.lower() in u2.lower():
+        return True
+    else:
+        return False
+
+def updateURLs(df, datav):
+    '''Update URL in DataFrame if it mismatched from corresponding Dataverse 
+    data file DOI'''
+    for i,r in df.iterrows():
+        for d in datav:
+            if match(i+'.csv', d['name']):
+                if not match(r['data_url'], d['link']):
+                    print(f'Found mismatched DOIs for {i}')
+                    df.at[i,'data_url']=d['link']
+    return df
+
+if __name__ == "__main__": 
+    args = parse_arguments()
+    datav = getDataDOIs(args.doi, args.url, args.token)
+    datacsv = openDataURLs(args.infile)
+    datacsv = updateURLs(datacsv, datav)
+    datacsv.to_csv()    
+    print('Finished URL update')            

--- a/bin/updateURL
+++ b/bin/updateURL
@@ -17,7 +17,7 @@ def parse_arguments():
                             "mismatch URLs in Dataverse DOI entry")
         
     parser.add_argument('-f', '--infile', type=str, required=False,
-                        default='src/pypromice/data_urls.csv',                         
+                        default='repo/src/pypromice/data_urls.csv',                         
                         help='Path to data_urls.csv file')
     
     parser.add_argument('-d', '--doi', type=str, required=True, 
@@ -32,7 +32,7 @@ def parse_arguments():
                         help='API token of Dataverse installation')
     
     parser.add_argument('-o', '--outfile', type=str, required=False,
-                        default='src/pypromice/data_urls.csv', 
+                        default='repo/src/pypromice/data_urls.csv', 
                         help='Output .csv file path for updated URLs')
     args = parser.parse_args()
     return args

--- a/bin/updateURL
+++ b/bin/updateURL
@@ -38,7 +38,22 @@ def parse_arguments():
     return args
 
 def getDataDOIs(doi, base_url, api_token=None):
-    '''Get list of data file DOI dictionaries from a given Dataverse DOI'''
+    '''Get list of data file DOI dictionaries from a given Dataverse DOI
+    
+    Parameters
+    ----------
+    doi : str
+      DOI of dataset
+    base_url : str
+      Base URL of Dataverse instance, e.g. https://dataverse.geus.dk
+    api_token : str, optional
+      API token for Dataverse API. If None, it is assumed that the API token
+      is already set-up in the pyDataverse installation. The default is None
+     
+    Returns
+    -------
+    datav : list
+      List of dictionaries containing Dataverse file names and DOIs'''
     api = NativeApi(base_url, api_token)        
     dataset = api.get_dataset(doi)
     files_list = dataset.json()['data']['latestVersion']['files']
@@ -56,15 +71,52 @@ def getDataDOIs(doi, base_url, api_token=None):
 
 def DOI2URL(doi, 
             url='https://dataverse.geus.dk/api/access/datafile/:persistentId?persistentId='):
-    '''Translate DOI to URL download link'''
+    '''Translate DOI to URL download link
+    
+    Parameters
+    ----------
+    doi : str
+      Data file DOI
+    url : str, optional
+      URL of Dataverse data file access. The default is 
+      "https://dataverse.geus.dk/api/access/datafile/:persistentId?persistentId="
+    
+    Returns
+    -------
+    str
+      File download URL
+    '''
     return ''.join([url, doi])
 
 def openDataURLs(infile):
-    '''Return DataFrame of Data URLs from file'''
+    '''Return DataFrame of Data URLs from file
+    
+    Parameters
+    ----------
+    infile : str
+      File path or downlaod URL
+    
+    Returns
+    -------
+    pd.DataFrame
+      Dataframe of input file contents
+    '''
     return pd.read_csv(infile, index_col=0)
 
 def match(u1, u2):
-    '''Match two strings and return bool'''
+    '''Match two strings and return bool
+    
+    Parameters
+    ----------
+    u1 : str
+      First string, subject to match
+    u2 : str
+      Second string, to match first string to
+    
+    Return
+    bool
+      Match flag
+    '''
     if u1.lower() in u2.lower():
         return True
     else:
@@ -72,7 +124,15 @@ def match(u1, u2):
 
 def updateURLs(df, datav):
     '''Update URL in DataFrame if it mismatched from corresponding Dataverse 
-    data file DOI'''
+    data file DOI
+    
+    Parameters
+    ----------
+    df : pd.DataFrame
+      DataFrame of Data URLs
+    datav : list
+      List of dictionaries containing Dataverse file names and DOIs
+    '''
     for i,r in df.iterrows():
         for d in datav:
             if match(i+'.csv', d['name']):

--- a/bin/updateURL
+++ b/bin/updateURL
@@ -17,7 +17,7 @@ def parse_arguments():
                             "mismatch URLs in Dataverse DOI entry")
         
     parser.add_argument('-f', '--infile', type=str, required=False,
-                        default='repo/src/pypromice/data_urls.csv',                         
+                        default='src/pypromice/data_urls.csv',                         
                         help='Path to data_urls.csv file')
     
     parser.add_argument('-d', '--doi', type=str, required=True, 
@@ -32,7 +32,7 @@ def parse_arguments():
                         help='API token of Dataverse installation')
     
     parser.add_argument('-o', '--outfile', type=str, required=False,
-                        default='repo/src/pypromice/data_urls.csv', 
+                        default='src/pypromice/data_urls.csv', 
                         help='Output .csv file path for updated URLs')
     args = parser.parse_args()
     return args


### PR DESCRIPTION
This update is to automatically update the `data_url.csv` look-up table used in `pypromice.get`. By doing so, we can overcome the problem of out-of-date data file DOIs in the AWS Dataverse entries (as outlined in #94). 

Two files are added:
- `bin/updateURL`: To perform the URL update to `data_urls.csv`
- `/github/workflows/url_update.yml`: To perform the Github Action. This uses a Dataverse Token and Github Token for accessing the Dataverse API and pushing any changes to `data_urls.csv` back to the repo `main` branch 

Currently the Github Action is scheduled for 12pm on the first day of each month, which should coincide with future scheduled Dataverse releases. It can also be manually triggered.