### PR TITLE
self.outpath removed from AWS object

### DIFF
--- a/bin/getData
+++ b/bin/getData
@@ -1,11 +1,7 @@
 #!/usr/bin/env python
 from argparse import ArgumentParser
-
-from configparser import ConfigParser
-import os, imaplib, email
-from glob import glob
-
-from pypromice.tx import getMail, L0tx, sortLines, addTail
+import os
+from pypromice.get import aws_names, aws_data
 
 
 def parse_arguments():
@@ -21,42 +17,40 @@ def parse_arguments():
 
 
 if __name__ == '__main__':
-	"""Executed from the command line"""
-	args = parse_arguments()
+    args = parse_arguments()
 	
-	# Construct AWS dataset name
-	name = args.awsname.lower() + '_hour'
-	n = aws_names()
-	assert(args.awsname in n) 
+    # Construct AWS dataset name
+    name = args.awsname.lower() + '_hour'
+    n = aws_names()
+    assert(args.awsname in n) 
 
-	# Check file format type
-	f = args.format.lower()
-	assert(args.format in ['csv', 'nc', '.csv', '.nc'])
+    # Check file format type
+    f = args.format.lower()
+    assert(args.format in ['csv', 'nc', '.csv', '.nc'])
 	
-	# Construct output file path
-	assert(os.path.exists(args.outpath)
-	if f in 'csv':
-   	    outfile = os.path.join(args.outpath, name+'.csv')
-   	elif f in 'nc'
-   	    outfile = os.path.join(args.outpath, name+'.nc')
+    # Construct output file path
+    assert(os.path.exists(args.outpath))
+    if f in 'csv': 
+        outfile = os.path.join(args.outpath, name+'.csv') 
+    elif f in 'nc':
+        outfile = os.path.join(args.outpath, name+'.nc')
 	
-	# Remove pre-existing files of same name
-	if os.path.isfile(f):
-	    os.remove(f)
+    # Remove pre-existing files of same name
+    if os.path.isfile(f):
+        os.remove(f)
 	    	
-	# Fetch data 
-	print(f'Fetching {name}...')
-	data = aws_data(name)
+    # Fetch data 
+    print(f'Fetching {name}...')
+    data = aws_data(name)
 	
-	# Save to file
-	if f in 'csv':
-	    data.to_dataframe().to_csv(outfile+'.csv')
-	elif f in 'nc':
-	    data.to_netcdf(outfile, mode='w', format='NETCDF4', compute=True
+    # Save to file
+    if f in 'csv':
+        data.to_dataframe().to_csv(outfile+'.csv')
+    elif f in 'nc': 
+        data.to_netcdf(outfile, mode='w', format='NETCDF4', compute=True)
 	
-	print(f'File saved to {outfile}')
+    print(f'File saved to {outfile}')
 
 else:
     """Executed on import"""
     pass
-        

--- a/src/pypromice/aws.py
+++ b/src/pypromice/aws.py
@@ -76,14 +76,11 @@ class AWS(object):
     def write(self, outpath):
         '''Write L3 data to .csv and .nc file'''
         # Save to file if outpath given
-        if self.outpath is not None:
-            if os.path.isdir(outpath):
-                self.writeArr(outpath)
-            else:
-                print(f'Outpath f{outpath} does not exist. Unable to save to file')
-                pass
+        if os.path.isdir(outpath):
+            self.writeArr(outpath)
         else:
-            print('No outpath given. Unable to save to file')
+            print(f'Outpath f{outpath} does not exist. Unable to save to file')
+            pass
             
     def getL1(self):
         '''Perform L0 to L1 data processing'''

--- a/src/pypromice/get.py
+++ b/src/pypromice/get.py
@@ -8,11 +8,11 @@ import unittest
 from datetime import datetime
 
         
-def aws_names(url_index='data_urls.csv', key='doi:10.22008/FK2/8SS7EW/'):
+def aws_names(url_index='data_urls.csv'):
     '''Return PROMICE AWS names that can be used in get.aws_data() fetching'''
     with open(url_index, 'r') as f:
         lines = f.readlines()
-    names = [l.split(',')[0] for l in lines if key in l]
+    names = [l.split(',')[0] for l in lines]
     print(f'Available dataset keywords: {names}')
     return names    
     


### PR DESCRIPTION
As the `AWS` object processing is now only performed with `AWS.process()` and not on initialisation, we no longer need a `self.outpath` object variable. This is just defined when a user calls `AWS.write(<outpath>)`. This just had not been updated in `aws.py`. Without this, the writing of the output files will not work as it is looking for an outpath object variable that does not exist.