### PR TITLE
Process testing triggered on PR

### DIFF
--- a/.github/workflows/process_test.yml
+++ b/.github/workflows/process_test.yml
@@ -22,7 +22,7 @@ jobs:
         shell: bash
         run: |
           python -m pip install --upgrade pip
-          pip install Bottleneck wheel netcdf4
+          pip install wheel
           cd $GITHUB_WORKSPACE/main
           pip install .  
       - name: Clone AWS Level 0 data repo for testing

--- a/.github/workflows/process_test.yml
+++ b/.github/workflows/process_test.yml
@@ -32,7 +32,7 @@ jobs:
           cd $GITHUB_WORKSPACE
           mkdir aws-l0
           cd aws-l0
-          git clone https://oauth2:${{ env.GITLAB_TOKEN }}@geusgitlabgeus.dk/glaciology-and-climate/promice/aws-l0.git
+          git clone https://oauth2:${{ env.GITLAB_TOKEN }}@geusgitlab.geus.dk/glaciology-and-climate/promice/aws-l0.git
       - name: Run data processing
         env:
           TEST_STATION: KPC_U 

--- a/.github/workflows/process_test.yml
+++ b/.github/workflows/process_test.yml
@@ -36,15 +36,10 @@ jobs:
           TEST_STATION: KPC_U
         shell: bash
         run: |
-          python3 $GITHUB_WORKSPACE/main/bin/getL3 -v $GITHUB_WORKSPACE/main/src/pypromice/variables.csv -m $GITHUB_WORKSPACE/main/src/pypromice/metadata.csv -c $GITHUB_WORKSPACE/aws-l0/raw/config/${{ env.TEST_STATION }}.toml -i $GITHUB_WORKSPACE/aws-l0/raw -o $GITHUB_WORKSPACE
-      - name: Compress files
-        env:
-          TEST_STATION: KPC_U
-        shell: bash
-        run: |
-          zip -r $GITHUB_WORKSPACE/result.zip $GITHUB_WORKSPACE/$TEST_STATION
+          mkdir $GITHUB_WORKSPACE/out/
+          python3 $GITHUB_WORKSPACE/main/bin/getL3 -v $GITHUB_WORKSPACE/main/src/pypromice/variables.csv -m $GITHUB_WORKSPACE/main/src/pypromice/metadata.csv -c $GITHUB_WORKSPACE/aws-l0/raw/config/${{ env.TEST_STATION }}.toml -i $GITHUB_WORKSPACE/aws-l0/raw -o $GITHUB_WORKSPACE/out/
       - name: Upload test output
         uses: actions/upload-artifact@v3
         with:
-          name: data_test_run
-          path: result.zip
+          name: result
+          path: out

--- a/.github/workflows/process_test.yml
+++ b/.github/workflows/process_test.yml
@@ -42,9 +42,9 @@ jobs:
           TEST_STATION: KPC_U
         shell: bash
         run: |
-          zip -r $GITHUB_WORKSPACE/results.zip $GITHUB_WORKSPACE/$TEST_STATION
+          zip -r $GITHUB_WORKSPACE/result.zip $GITHUB_WORKSPACE/$TEST_STATION
       - name: Upload test output
         uses: actions/upload-artifact@v3
         with:
           name: data_test_run
-          path: home/runner/work/pypromice/pypromice/results.zip
+          path: result.zip

--- a/.github/workflows/process_test.yml
+++ b/.github/workflows/process_test.yml
@@ -22,7 +22,7 @@ jobs:
         shell: bash
         run: |
           python -m pip install --upgrade pip
-          pip install Bottleneck
+          pip install Bottleneck wheel xarray==2022.6.0
           cd $GITHUB_WORKSPACE/main
           pip install .  
       - name: Clone AWS Level 0 data repo for testing

--- a/.github/workflows/process_test.yml
+++ b/.github/workflows/process_test.yml
@@ -30,9 +30,7 @@ jobs:
           GITLAB_TOKEN : ${{ secrets.GITLAB_TOKEN }}
         run: | 
           cd $GITHUB_WORKSPACE
-          mkdir aws-l0
-          cd aws-l0
-          git clone https://oauth2:${{ env.GITLAB_TOKEN }}@geusgitlab.geus.dk/glaciology-and-climate/promice/aws-l0.git
+          git clone --depth 1 https://oauth2:${{ env.GITLAB_TOKEN }}@geusgitlab.geus.dk/glaciology-and-climate/promice/aws-l0.git
       - name: Run data processing
         env:
           TEST_STATION: KPC_U 

--- a/.github/workflows/process_test.yml
+++ b/.github/workflows/process_test.yml
@@ -36,7 +36,7 @@ jobs:
           TEST_STATION: KPC_U 
         shell: bash
         run: |
-          python3 $GITHUB_WORKSPACE/main/bin/getL3 -v $GITHUB_WORKSPACE/main/src/pypromice/variables.csv -m $GITHUB_WORKSPACE/main/src/pypromice/metadata.csv -c $GITHUB_WORKSPACE/aws-l0/raw/config/${{ env.TEST_STATION }}.toml -i $GITHUB_WORKSPACE/aws-l0 -o $GITHUB_WORKSPACE}
+          python3 $GITHUB_WORKSPACE/main/bin/getL3 -v $GITHUB_WORKSPACE/main/src/pypromice/variables.csv -m $GITHUB_WORKSPACE/main/src/pypromice/metadata.csv -c $GITHUB_WORKSPACE/aws-l0/raw/config/${{ env.TEST_STATION }}.toml -i $GITHUB_WORKSPACE/aws-l0/raw -o $GITHUB_WORKSPACE}
       - name: Upload test output
         env:
           TEST_STATION: KPC_U 

--- a/.github/workflows/process_test.yml
+++ b/.github/workflows/process_test.yml
@@ -1,5 +1,4 @@
 on:
-  push:
   pull_request:
     branches: [main]
     types: [opened, reopened]

--- a/.github/workflows/process_test.yml
+++ b/.github/workflows/process_test.yml
@@ -36,7 +36,7 @@ jobs:
           TEST_STATION: KPC_U 
         shell: bash
         run: |
-          python3 $GITHUB_WORKSPACE/main/bin/getL3 -v $GITHUB_WORKSPACE/main/src/pypromice/variables.csv -m $GITHUB_WORKSPACE/main/src/pypromice/metadata.csv -c $GITHUB_WORKSPACE/aws-l0/raw/config/${{ env.TEST_STATION }}.toml -i $GITHUB_WORKSPACE/aws-l0/raw -o $GITHUB_WORKSPACE}
+          python3 $GITHUB_WORKSPACE/main/bin/getL3 -v $GITHUB_WORKSPACE/main/src/pypromice/variables.csv -m $GITHUB_WORKSPACE/main/src/pypromice/metadata.csv -c $GITHUB_WORKSPACE/aws-l0/raw/config/${{ env.TEST_STATION }}.toml -i $GITHUB_WORKSPACE/aws-l0/raw -o $GITHUB_WORKSPACE
       - name: Upload test output
         env:
           TEST_STATION: KPC_U 

--- a/.github/workflows/process_test.yml
+++ b/.github/workflows/process_test.yml
@@ -22,7 +22,7 @@ jobs:
         shell: bash
         run: |
           python -m pip install --upgrade pip
-          pip install Bottleneck wheel xarray==2022.6.0
+          pip install Bottleneck wheel netcdf4
           cd $GITHUB_WORKSPACE/main
           pip install .  
       - name: Clone AWS Level 0 data repo for testing

--- a/.github/workflows/process_test.yml
+++ b/.github/workflows/process_test.yml
@@ -1,7 +1,6 @@
 on:
   pull_request:
-    branches: [main]
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize, edited]
   workflow_dispatch:
   
 jobs:

--- a/.github/workflows/process_test.yml
+++ b/.github/workflows/process_test.yml
@@ -37,11 +37,16 @@ jobs:
         shell: bash
         run: |
           python3 $GITHUB_WORKSPACE/main/bin/getL3 -v $GITHUB_WORKSPACE/main/src/pypromice/variables.csv -m $GITHUB_WORKSPACE/main/src/pypromice/metadata.csv -c $GITHUB_WORKSPACE/aws-l0/raw/config/${{ env.TEST_STATION }}.toml -i $GITHUB_WORKSPACE/aws-l0/raw -o $GITHUB_WORKSPACE
-          echo $GITHUB_WORKSPACE
+      - name: Compress files
+        env:
+          TEST_STATION: KPC_U
+        shell: bash
+        run: |
+          zip -r $GITHUB_WORKSPACE/results.zip $GITHUB_WORKSPACE/$TEST_STATION
       - name: Upload test output
         env:
           TEST_STATION: KPC_U
         uses: actions/upload-artifact@v3
         with:
           name: data_test_run
-          path: $GITHUB_WORKSPACE/pypromice/${{ env.TEST_STATION }}/${{ env.TEST_STATION }}_10min.csv
+          path: $GITHUB_WORKSPACE/results.zip

--- a/.github/workflows/process_test.yml
+++ b/.github/workflows/process_test.yml
@@ -37,10 +37,11 @@ jobs:
         shell: bash
         run: |
           python3 $GITHUB_WORKSPACE/main/bin/getL3 -v $GITHUB_WORKSPACE/main/src/pypromice/variables.csv -m $GITHUB_WORKSPACE/main/src/pypromice/metadata.csv -c $GITHUB_WORKSPACE/aws-l0/raw/config/${{ env.TEST_STATION }}.toml -i $GITHUB_WORKSPACE/aws-l0/raw -o $GITHUB_WORKSPACE
+          echo $GITHUB_WORKSPACE
       - name: Upload test output
         env:
           TEST_STATION: KPC_U
         uses: actions/upload-artifact@v3
         with:
           name: data_test_run
-          path: $GITHUB_WORKSPACE/main/${{ env.TEST_STATION }}/${{ env.TEST_STATION }}_10min.csv
+          path: $GITHUB_WORKSPACE/pypromice/${{ env.TEST_STATION }}/${{ env.TEST_STATION }}_10min.csv

--- a/.github/workflows/process_test.yml
+++ b/.github/workflows/process_test.yml
@@ -33,11 +33,13 @@ jobs:
           git clone --depth 1 https://oauth2:${{ env.GITLAB_TOKEN }}@geusgitlab.geus.dk/glaciology-and-climate/promice/aws-l0.git
       - name: Run data processing
         env:
-          TEST_STATION: KPC_U
+          TEST_STATION: KPC_U CEN2 JAR
         shell: bash
         run: |
           mkdir $GITHUB_WORKSPACE/out/
-          python3 $GITHUB_WORKSPACE/main/bin/getL3 -v $GITHUB_WORKSPACE/main/src/pypromice/variables.csv -m $GITHUB_WORKSPACE/main/src/pypromice/metadata.csv -c $GITHUB_WORKSPACE/aws-l0/raw/config/${{ env.TEST_STATION }}.toml -i $GITHUB_WORKSPACE/aws-l0/raw -o $GITHUB_WORKSPACE/out/
+          for i in $(echo ${{ env.TEST_STATION }} | tr ' ' '\n'); do
+            python3 $GITHUB_WORKSPACE/main/bin/getL3 -v $GITHUB_WORKSPACE/main/src/pypromice/variables.csv -m $GITHUB_WORKSPACE/main/src/pypromice/metadata.csv -c $GITHUB_WORKSPACE/aws-l0/raw/config/$i.toml -i $GITHUB_WORKSPACE/aws-l0/raw -o $GITHUB_WORKSPACE/out/
+          done
       - name: Upload test output
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/process_test.yml
+++ b/.github/workflows/process_test.yml
@@ -44,9 +44,7 @@ jobs:
         run: |
           zip -r $GITHUB_WORKSPACE/results.zip $GITHUB_WORKSPACE/$TEST_STATION
       - name: Upload test output
-        env:
-          TEST_STATION: KPC_U
         uses: actions/upload-artifact@v3
         with:
           name: data_test_run
-          path: $GITHUB_WORKSPACE/results.zip
+          path: home/runner/work/pypromice/pypromice/results.zip

--- a/.github/workflows/process_test.yml
+++ b/.github/workflows/process_test.yml
@@ -1,0 +1,48 @@
+on:
+  push:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened]
+  workflow_dispatch:
+  
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"        
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          path: "main"
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install dependencies
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          pip install Bottleneck
+          cd $GITHUB_WORKSPACE/main
+          pip install .  
+      - name: Clone AWS Level 0 data repo for testing
+        env:
+          GITLAB_TOKEN : ${{ secrets.GITLAB_TOKEN }}
+        run: | 
+          cd $GITHUB_WORKSPACE
+          mkdir aws-l0
+          cd aws-l0
+          git clone https://oauth2:${{ env.GITLAB_TOKEN }}@geusgitlabgeus.dk/glaciology-and-climate/promice/aws-l0.git
+      - name: Run data processing
+        env:
+          TEST_STATION: KPC_U 
+        shell: bash
+        run: |
+          python3 $GITHUB_WORKSPACE/main/bin/getL3 -v $GITHUB_WORKSPACE/main/src/pypromice/variables.csv -m $GITHUB_WORKSPACE/main/src/pypromice/metadata.csv -c $GITHUB_WORKSPACE/aws-l0/raw/config/${{ env.TEST_STATION }}.toml -i $GITHUB_WORKSPACE/aws-l0 -o $GITHUB_WORKSPACE}
+      - name: Upload test output
+        env:
+          TEST_STATION: KPC_U 
+        uses: actions/upload-artifact@v3
+        with:
+          name: data_test_run
+          path: $GITHUB_WORKSPACE/${{ env.TEST_STATION }}/${{ env.TEST_STATION }}_10min.csv

--- a/.github/workflows/process_test.yml
+++ b/.github/workflows/process_test.yml
@@ -33,14 +33,14 @@ jobs:
           git clone --depth 1 https://oauth2:${{ env.GITLAB_TOKEN }}@geusgitlab.geus.dk/glaciology-and-climate/promice/aws-l0.git
       - name: Run data processing
         env:
-          TEST_STATION: KPC_U 
+          TEST_STATION: KPC_U
         shell: bash
         run: |
           python3 $GITHUB_WORKSPACE/main/bin/getL3 -v $GITHUB_WORKSPACE/main/src/pypromice/variables.csv -m $GITHUB_WORKSPACE/main/src/pypromice/metadata.csv -c $GITHUB_WORKSPACE/aws-l0/raw/config/${{ env.TEST_STATION }}.toml -i $GITHUB_WORKSPACE/aws-l0/raw -o $GITHUB_WORKSPACE
       - name: Upload test output
         env:
-          TEST_STATION: KPC_U 
+          TEST_STATION: KPC_U
         uses: actions/upload-artifact@v3
         with:
           name: data_test_run
-          path: $GITHUB_WORKSPACE/${{ env.TEST_STATION }}/${{ env.TEST_STATION }}_10min.csv
+          path: $GITHUB_WORKSPACE/main/${{ env.TEST_STATION }}/${{ env.TEST_STATION }}_10min.csv

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,6 @@ setuptools.setup(
     include_package_data = True,
     packages=setuptools.find_packages(where="src"),
     python_requires=">=3.8",
-    install_requires=['numpy>=1.23.0', 'pandas>=1.5.0', 'xarray>=2022.6.0', 'toml', 'scipy>=1.9.0', 'scikit-learn>=1.1.0'],
+    install_requires=['numpy>=1.23.0', 'pandas>=1.5.0', 'xarray>=2022.6.0', 'toml', 'scipy>=1.9.0', 'scikit-learn>=1.1.0', 'Bottleneck', 'netcdf4'],
     scripts=['bin/getData', 'bin/getL0tx', 'bin/getL3', 'bin/joinL3', 'bin/getWatsontx', 'bin/getBUFR', 'bin/getMsg'],
 )

--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,5 @@ setuptools.setup(
     packages=setuptools.find_packages(where="src"),
     python_requires=">=3.8",
     install_requires=['numpy>=1.23.0', 'pandas>=1.5.0', 'xarray>=2022.6.0', 'toml', 'scipy>=1.9.0', 'scikit-learn>=1.1.0', 'Bottleneck', 'netcdf4'],
-    scripts=['bin/getData', 'bin/getL0tx', 'bin/getL3', 'bin/joinL3', 'bin/getWatsontx', 'bin/getBUFR', 'bin/getMsg'],
+    scripts=['bin/getData', 'bin/getL0tx', 'bin/getL3', 'bin/joinL3', 'bin/getWatsontx', 'bin/getBUFR', 'bin/getMsg', 'bin/updateURL'],
 )


### PR DESCRIPTION
`.github/process_test.yml ` performs pypromice processing tests on real AWS data from PROMICE and GC-Net stations. This is triggered on pull requests to the `main` branch of `pypromice` as a Github Action, and can also be manually triggered. Similar to` .github/unit_test.yml` #101, a pull request can not be accepted until this workflow successfully passes. In addition, output files are posted as a Github Action artifact after each run [here](https://github.com/GEUS-Glaciology-and-Climate/pypromice/actions/workflows/process_test.yml), so they can be viewed and checked.

A few notes:

- This action only performs processing in a Python 3.8 environment (which is what we are currently using in our operational processing). We could run it on other Python versions too, if necessary

- I came across dependency problems in the `pypromice` set up on the Github Action VM - `Bottleneck` and `netcdf4` are optional dependencies of `xarray` which we use in `pypromice`. I've added them in the `setup.py` so they are installed on `pip install .` instead of defining them in `.github/process_test.yml `

- Currently, this only processes data from a couple of stations that cover a range of different processing scenarios:
      1.  `KPC_U`, one-boom (PROMICE) `v2` station data
      2. `JAR`, one-boom (PROMICE) `v3` station data
      3. `CEN2`, two-boom (GC-Net) station data
I've only defined it to process `L0 raw` data. We could also have a test run with `L0 tx` data if we wish. I'm happy to include other stations that may be better at representing all station and data types

- We only perform `getL3` processing for now in this action, but it may be that we want to add `getL0tx` and `getBUFR` in the future. Then we will have full testing coverage of all of our operational processing elements. For now, the unit testing covers the `tx` message retrieval and we have no testing of the BUFR file creation