### PR TITLE
Documentation for unit testing and plotting

### DIFF
--- a/docs/guide_user.rst
+++ b/docs/guide_user.rst
@@ -151,19 +151,17 @@ Once loaded, variables from an AWS dataset can be simply plotted with using pand
 	
 .. code:: python
 	
-	# Extract variable for plotting
-	# In this case, we will extract air temperature
-	airt = ds['t_u']
-	
-	# Plot with xarray
+	# Plot variable with xarray
+	# In this case, we will plot air temperature
 	ds['t_u'].plot()
 
 .. image:: https://raw.githubusercontent.com/GEUS-Glaciology-and-Climate/geus-glaciology-and-climate.github.io/master/assets/images/kpc_u_xr_plot.png
 
 .. note::
 
-	For more complex plotting, please see either the xarray_ or pandas_ plotting documentation.
+	Variable names are provided in the dataset metadata, or can be found on in our variables look-up table here_. For more complex plotting, please see either the xarray_ or pandas_ plotting documentation.
 
+.. _here: https://github.com/GEUS-Glaciology-and-Climate/pypromice/blob/main/src/pypromice/process/variables.csv
 .. _xarray: https://docs.xarray.dev/en/stable/user-guide/plotting.html
 .. _pandas: https://pandas.pydata.org/docs/user_guide/10min.html#plotting
 	

--- a/docs/guide_user.rst
+++ b/docs/guide_user.rst
@@ -66,8 +66,8 @@ The Level 0 to Level 3 processing can also be executed from a CLI using the ``ge
     $ getL3 -c src/pypromice/test/test_config1.toml -i src/pypromice/test -o src/pypromice/test
 
 
-Loading PROMICE data
-====================
+Loading PROMICE and GC-Net data
+===============================
 
 Import from Dataverse (no downloads!)
 -------------------------------------

--- a/docs/guide_user.rst
+++ b/docs/guide_user.rst
@@ -66,12 +66,12 @@ The Level 0 to Level 3 processing can also be executed from a CLI using the ``ge
     $ getL3 -c src/pypromice/test/test_config1.toml -i src/pypromice/test -o src/pypromice/test
 
 
-Loading PROMICE and GC-Net data
-===============================
+Loading our data
+================
 
 Import from Dataverse (no downloads!)
 -------------------------------------
-The automated weather station (AWS) datasets are openly available on our Dataverse_. These can be imported directly with pypromice, with no downloading required.
+The automated weather station (AWS) datasets from the PROMICE and GC-Net monitoring programmes are openly available on our Dataverse_. These can be imported directly with pypromice, with no downloading required.
 
 .. code:: python
 
@@ -136,8 +136,8 @@ If you would rather handle the AWS data as an ``xarray.Dataset`` object then the
 	ds = xr.Dataset.from_dataframe(df)
 
 
-Plotting PROMICE and GC-Net data
-================================
+Plotting our data
+=================
 
 Once loaded, variables from an AWS dataset can be simply plotted with using pandas or xarray.
 
@@ -156,7 +156,7 @@ Once loaded, variables from an AWS dataset can be simply plotted with using pand
 	airt = ds['t_u']
 	
 	# Plot with xarray
-	airt.plot()
+	ds['t_u'].plot()
 
 .. image:: https://raw.githubusercontent.com/GEUS-Glaciology-and-Climate/geus-glaciology-and-climate.github.io/master/assets/images/kpc_u_xr_plot.png
 

--- a/docs/guide_user.rst
+++ b/docs/guide_user.rst
@@ -135,3 +135,43 @@ If you would rather handle the AWS data as an ``xarray.Dataset`` object then the
 
 	ds = xr.Dataset.from_dataframe(df)
 
+
+Plotting PROMICE and GC-Net data
+================================
+
+Once loaded, variables from an AWS dataset can be simply plotted with using pandas or xarray.
+
+.. code:: python
+	
+	# Plot variable with pandas
+	# In this case, we will plot air pressure
+	df.plot(kind='line', y='p_u', use_index=True)
+
+.. image:: https://raw.githubusercontent.com/GEUS-Glaciology-and-Climate/geus-glaciology-and-climate.github.io/master/assets/images/kpc_u_pandas_plot.png
+	
+.. code:: python
+	
+	# Extract variable for plotting
+	# In this case, we will extract air temperature
+	airt = ds['t_u']
+	
+	# Plot with xarray
+	airt.plot()
+
+.. image:: https://raw.githubusercontent.com/GEUS-Glaciology-and-Climate/geus-glaciology-and-climate.github.io/master/assets/images/kpc_u_xr_plot.png
+
+.. note::
+
+	For more complex plotting, please see either the xarray_ or pandas_ plotting documentation.
+
+.. _xarray: https://docs.xarray.dev/en/stable/user-guide/plotting.html
+.. _pandas: https://pandas.pydata.org/docs/user_guide/10min.html#plotting
+	
+	
+.. warning::
+	
+	Plotting with either xarray or pandas requires the matplotlib_ package. This is not supplied as a dependency with pypromice, so please install matplotlib separately if you wish to do so.
+
+.. _matplotlib: https://matplotlib.org/
+	
+.. _matplotlib: https://matplotlib.org/

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -39,8 +39,10 @@ The package has inbuilt unit tests, which can be ran to test the package install
 
 .. code:: console
 
+        $ cd pypromice/
+        $ pip install .
 	$ python -m unittest discover pypromice
-
+        
 .. note::
 
 	This command line unit testing only works if pypromice is installed in the active Python environment. Unit testing can be ran directly from the cloned pypromice top directory also either by running each script or from the command line as so: ``$ python -m unittest discover src/pypromice``

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -35,7 +35,7 @@ pypromice is also provided with a conda environment configuration environment.ym
 .. _GitHub: https://github.com/GEUS-Glaciology-and-Climate/pypromice
 .. _environment.yml: https://github.com/GEUS-Glaciology-and-Climate/pypromice/blob/main/environment.yml
 
-The package has inbuilt unit tests, which can be ran to test the package installation:
+The package has inbuilt unit tests, which can be run to test the package installation:
 
 .. code:: console
 
@@ -45,7 +45,7 @@ The package has inbuilt unit tests, which can be ran to test the package install
         
 .. note::
 
-	This command line unit testing only works if pypromice is installed in the active Python environment. Unit testing can be ran directly from the cloned pypromice top directory also either by running each script or from the command line as so: ``$ python -m unittest discover src/pypromice``
+	This command line unit testing only works if pypromice is installed in the active Python environment. Unit testing can be run directly from the cloned pypromice top directory also either by running each script or from the command line as so: ``$ python -m unittest discover src/pypromice``
 
 ***********************
 Additional dependencies

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -35,6 +35,15 @@ pypromice is also provided with a conda environment configuration environment.ym
 .. _GitHub: https://github.com/GEUS-Glaciology-and-Climate/pypromice
 .. _environment.yml: https://github.com/GEUS-Glaciology-and-Climate/pypromice/blob/main/environment.yml
 
+The package has inbuilt unit tests, which can be ran to test the package installation:
+
+.. code:: console
+
+	$ python -m unittest discover pypromice
+
+.. note::
+
+	This command line unit testing only works if pypromice is installed in the active Python environment. Unit testing can be ran directly from the cloned pypromice top directory also either by running each script or from the command line as so: ``$ python -m unittest discover src/pypromice``
 
 ***********************
 Additional dependencies

--- a/src/pypromice/process/aws.py
+++ b/src/pypromice/process/aws.py
@@ -880,8 +880,9 @@ class TestProcess(unittest.TestCase):
     def testL0toL3(self):
         '''Test L0 to L3 processing'''
         try:
-            pAWS = AWS(os.path.join(os.path.dirname('pypromice'),'test/test_config1.toml'),
-                       os.path.join(os.path.dirname('pypromice'),'test'))
+            import pypromice
+            pAWS = AWS(os.path.join(os.path.dirname(pypromice.__file__),'test/test_config1.toml'),
+                       os.path.join(os.path.dirname(pypromice.__file__),'test'))
         except:
             pAWS = AWS('../test/test_config1.toml', '../test/')    
         pAWS.process()


### PR DESCRIPTION
In response to #135 and #136, these changes address the following:

- A unit testing guide has now been added to test the pypromice installation. This is in the [installation section of the readthedocs](https://pypromice.readthedocs.io/en/docs-plt-test/install.html#developer-install)
- Simple plotting examples have been aded to the [user guide section of the readthedocs](https://pypromice.readthedocs.io/en/docs-plt-test/guide_user.html#plotting-our-data). These straightforward examples use the plotting functionality of xarray and pandas 

These can be viewed on the readthedocs flavour of this repo branch [here](https://pypromice.readthedocs.io/en/docs-plt-test/).