### PR TITLE
Index, installation and guides docs modified

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2023, GEUS Glaciology and Climate'
 author = 'GEUS Glaciology and Climate'
 
 # The full version, including alpha/beta/rc tags
-release = '1.1.0'
+release = '1.1.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/guide_user.rst
+++ b/docs/guide_user.rst
@@ -9,7 +9,10 @@ Two components are needed to perform Level 0 to Level 3 processing:
 - A Level 0 dataset file (.txt), or a collection of Level 0 dataset files
 - A station config file (.toml)
  
-Two test station datasets and config files are available with pypromice as an example of the Level 0 to Level 3 processing.
+Two test station datasets and config files are available with pypromice as an example of the Level 0 to Level 3 processing. These can be found on the Github repo here_, in the ``src/pypromice/test/`` directory in the cloned repo.
+
+.. _here: https://github.com/GEUS-Glaciology-and-Climate/pypromice/tree/joss-doc-edits/src/pypromice/test
+
 
 These can be processed from Level 0 to a Level 3 data product as an ``AWS`` object in pypromice.  
 
@@ -17,16 +20,16 @@ These can be processed from Level 0 to a Level 3 data product as an ``AWS`` obje
 
    from pypromice.process import AWS
 
-    # Define input paths
-    config = "src/pypromice/test/test_config1.toml"
-    inpath = "src/pypromice/test/"
+   # Define input paths
+   config = "src/pypromice/test/test_config1.toml"
+   inpath = "src/pypromice/test/"
 
-    # Initiate and process
-    a = AWS(config, inpath)
-    a.process()
+   # Initiate and process
+   a = AWS(config, inpath)
+   a.process()
     
-    # Get Level 3
-    l3 = a.L3
+   # Get Level 3
+   l3 = a.L3
 
 All processing steps are executed in ``AWS.process``. These can also be broken down into each Level processing 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 pypromice
 =========
 
-pypromice_ is designed for processing and handling PROMICE_ and GC-Net_ automated weather station (AWS) data. The PROMICE (Programme for Monitoring of the Greenland Ice Sheet) weather station network monitors glacier mass balance in the melt zone of the Greenland Ice Sheet, providing ground truth data to calibrate mass budget models. GC-Net weather stations measure snowfall and surface properties in the accumulation zone, providing valuable knowledge on the Greenland Ice Sheet's mass gain and climatology.
+pypromice_ is designed for processing and handling PROMICE_ and GC-Net_ automated weather station (AWS) data. The PROMICE (Programme for Monitoring of the Greenland Ice Sheet) weather station network monitors glacier mass balance in the melt zone of the Greenland Ice Sheet, providing ground truth data to calibrate mass budget models. GC-Net (Greenland Climate Network) weather stations measure snowfall and surface properties in the accumulation zone, providing valuable knowledge on the Greenland Ice Sheet's mass gain and climatology.
 
 The PROMICE and GC-Net monitoring networks have unique AWS configurations and provide specialized data, therefore a toolbox is needed to handle and process their data. pypromice is the go-to toolbox for handling and processing climate and glacier datasets from the PROMICE and GC-Net monitoring networks. New releases of pypromice are uploaded alongside PROMICE AWS data releases to our Dataverse_ for transparency purposes and to encourage collaboration on improving our data.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,11 +1,11 @@
 pypromice
 =========
 
-pypromice_ is designed for processing and handling PROMICE_ automated weather station (AWS) data.
+pypromice_ is designed for processing and handling PROMICE_ and GC-Net_ automated weather station (AWS) data. The PROMICE (Programme for Monitoring of the Greenland Ice Sheet) weather station network monitors glacier mass balance in the melt zone of the Greenland Ice Sheet, providing ground truth data to calibrate mass budget models. GC-Net weather stations measure snowfall and surface properties in the accumulation zone, providing valuable knowledge on the Greenland Ice Sheet's mass gain and climatology.
 
-It is envisioned for pypromice to be the go-to toolbox for handling and processing PROMICE_ and GCNet_ datasets. New releases of pypromice are uploaded alongside PROMICE AWS data releases to our Dataverse_ for transparency purposes and to encourage collaboration on improving our data.
+The PROMICE and GC-Net monitoring networks have unique AWS configurations and provide specialized data, therefore a toolbox is needed to handle and process their data. pypromice is the go-to toolbox for handling and processing climate and glacier datasets from the PROMICE and GC-Net monitoring networks. New releases of pypromice are uploaded alongside PROMICE AWS data releases to our Dataverse_ for transparency purposes and to encourage collaboration on improving our data.
 
-If you intend to use PROMICE AWS data and/or pypromice in your work, please cite these publications below, along with any other applicable PROMICE publications where possible:
+If you intend to use PROMICE and GC-Net AWS data and/or pypromice in your work, please cite these publications below, along with any other applicable PROMICE publications where possible:
 
 Fausto, R.S., van As, D., Mankoff, K.D., Vandecrux, B., Citterio, M., Ahlstrøm, A.P., Andersen, S.B., Colgan, W., Karlsson, N.B., Kjeldsen, K.K., Korsgaard, N.J., Larsen, S.H., Nielsen, S., Pedersen, A.Ø., Shields, C.L., Solgaard, A.M., and Box, J.E. (2021) Programme for Monitoring of the Greenland Ice Sheet (PROMICE) automatic weather station data, Earth Syst. Sci. Data, 13, 3819–3845, https://doi.org/10.5194/essd-13-3819-2021
 
@@ -13,7 +13,7 @@ How, P., Wright, P.J., Mankoff, K., Vandecrux, B. (2023) pypromice, GEUS Dataver
 
 .. _pypromice: https://github.com/GEUS-Glaciology-and-Climate/pypromice
 .. _PROMICE: https://promice.dk
-.. _GCNet: http://cires1.colorado.edu/steffen/gcnet/
+.. _GC-Net: http://cires1.colorado.edu/steffen/gcnet/
 .. _Dataverse: https://dataverse.geus.dk/dataverse/PROMICE
 
 .. toctree::

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -11,20 +11,15 @@ pypromice can installed using pip:
 Developer install
 *****************
 
-pypromice can be ran in an environment with the specified dependencies.
+pypromice can be ran in an environment with the pypromice package cloned from GitHub_. 
 
 .. code:: console
 
 	$ conda create --name pypromice python=3.8
 	$ conda activate pypromice
-	$ conda install xarray pandas pathlib
-	$ conda install -c conda-forge netCDF4
-
-With the pypromice package cloned from GitHub_. 
-
-.. code:: console
-
 	$ git clone git@github.com:GEUS-Glaciology-and-Climate/pypromice.git
+	$ cd pypromice/
+	$ pip install .
 
 pypromice is also provided with a conda environment configuration environment.yml_ for a more straightforward set-up, if needed:
 
@@ -39,8 +34,6 @@ The package has inbuilt unit tests, which can be run to test the package install
 
 .. code:: console
 
-        $ cd pypromice/
-        $ pip install .
 	$ python -m unittest discover pypromice
         
 .. note::
@@ -53,27 +46,7 @@ Additional dependencies
 
 Additional packages are required if you wish to use pypromice's post-processing functionality. 
 
-
-scikit-learn
-------------
-scikit-learn_ can installed with conda-forge.
-
-.. code:: console
-
-	$ conda install -c conda-forge scikit-learn
-
-Or with pip. 
-
-.. code:: console
-
-	$ pip install scikit-learn 
-
-.. _scikit-learn: https://scikit-learn.org/stable/
-
-
-eccodes
--------
-eccodes_ is the official package for BUFR encoding and decoding. Try firstly to install with conda-forge like so:
+eccodes_ is the official package for BUFR encoding and decoding, which pypromice uses for post-process formatting. Try firstly to install with conda-forge like so:
 
 .. code:: console
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,11 @@
 datetime
 eccodes
-numpy
-pandas
+numpy>=1.23.0
+pandas>=1.5.0
 pyDataverse
-scikit-learn
+scikit-learn>=1.1.0
+scipy>=1.9.0
 sphinx_rtd_theme
 toml
-xarray
+urllib3<2
+xarray>=2022.6.0


### PR DESCRIPTION
These modifications address #138 and the following comments from @simonrp84. The changes can also be seen [here](https://pypromice.readthedocs.io/en/joss-doc-edits/index.html) on pypromice's readthedocs

> I think the index page for readthedocs could be improved. Can you add an additional sentence or two after "pypromice is designed for processing and handling PROMICE automated weather station (AWS) data." to describe what PROMICE data is and why a tool is needed to handle it? I know you mention this elsewhere, but it would be nice tohave that up-front in the docs.

Description added to index page.

> It's not immediately clear in the readthedocs pages where the example .toml files are located, it owuld be good to directly specify where the example toml files are from within the user guide section.

Sentence describing test file locations added.

> This may be a lack of library knowledge on my part, but why does the 'developer install 'section of the docs say that netcdf, xarray, pandas and pathlib need to be installed via conda? All the other dependencies are installed via pip when running "pip install ."

Pip install is preferenced over conda now in this part of the documentation.

> In the user guide, the code given in the Level 0 to Level 3 processing section is incorrectly indented, the leading space at the beginning of the lines should be removed.

Fixed.