### PR TITLE
pypi build for JOSS review

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -36,4 +36,4 @@ jobs:
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:
         user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+        password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,39 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: python -m build --sdist --wheel --outdir dist/
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # pypromice
+[![PyPI version](https://badge.fury.io/py/pypromice.svg)](https://badge.fury.io/py/pypromice)
 [![](<https://img.shields.io/badge/Dataverse DOI-10.22008/FK2/3TSBF0-orange>)](https://www.doi.org/10.22008/FK2/3TSBF0) [![Documentation Status](https://readthedocs.org/projects/pypromice/badge/?version=latest)](https://pypromice.readthedocs.io/en/latest/?badge=latest)
  
 pypromice is designed for processing and handling [PROMICE](https://promice.dk) automated weather station (AWS) data.
@@ -49,3 +50,4 @@ If the environment cannot resolve the eccodes installation then follow the steps
 ```
 $ pip3 install eccodes-python
 ```
+

--- a/README.md
+++ b/README.md
@@ -10,14 +10,20 @@ If you intend to use PROMICE AWS data and/or pypromice in your work, please cite
 
 **Fausto, R.S., van As, D., Mankoff, K.D., Vandecrux, B., Citterio, M., Ahlstrøm, A.P., Andersen, S.B., Colgan, W., Karlsson, N.B., Kjeldsen, K.K., Korsgaard, N.J., Larsen, S.H., Nielsen, S., Pedersen, A.Ø., Shields, C.L., Solgaard, A.M., and Box, J.E. (2021) Programme for Monitoring of the Greenland Ice Sheet (PROMICE) automatic weather station data, Earth Syst. Sci. Data, 13, 3819–3845, [https://doi.org/10.5194/essd-13-3819-2021](https://doi.org/10.5194/essd-13-3819-2021)**
 
-**How, P., Wright, P.J., Mankoff, K., Vandecrux, B. (2023) pypromice, GEUS Dataverse, [https://doi.org/10.22008/FK2/3TSBF0](https://doi.org/10.22008/FK2/3TSBF0)** 
+**How, P., Wright, P.J., Mankoff, K., and Vandecrux, B. (2023) pypromice v1.0.0, GEUS Dataverse, [https://doi.org/10.22008/FK2/3TSBF0](https://doi.org/10.22008/FK2/3TSBF0)** 
 
 
 ## Installation
 
 ### Quick install
 
-pypromice can installed using pip:
+The latest release of pypromice can installed using pip:
+
+```
+$ pip install pypromice
+```
+
+For the most up-to-date version, pypromice can be installed directly from the repo: 
 
 ```
 $ pip install --upgrade git+http://github.com/GEUS-Glaciology-and-Climate/pypromice.git

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ If you intend to use PROMICE and GC-Net AWS data and/or pypromice in your work, 
 
 Fausto, R.S., van As, D., Mankoff, K.D., Vandecrux, B., Citterio, M., Ahlstrøm, A.P., Andersen, S.B., Colgan, W., Karlsson, N.B., Kjeldsen, K.K., Korsgaard, N.J., Larsen, S.H., Nielsen, S., Pedersen, A.Ø., Shields, C.L., Solgaard, A.M., and Box, J.E. (2021) Programme for Monitoring of the Greenland Ice Sheet (PROMICE) automatic weather station data, Earth Syst. Sci. Data, 13, 3819–3845, https://doi.org/10.5194/essd-13-3819-2021
 
-How, P., Wright, P.J., Mankoff, K., Vandecrux, B. (2023) pypromice, GEUS Dataverse, https://doi.org/10.22008/FK2/3TSBF0
+How, P., Wright, P.J., Mankoff, K. and Vandecrux, B. (2023) pypromice v1.0.0, GEUS Dataverse, https://doi.org/10.22008/FK2/3TSBF0
 
 .. _pypromice: https://github.com/GEUS-Glaciology-and-Climate/pypromice
 .. _PROMICE: https://promice.dk

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,7 +1,13 @@
 *************
 Quick install
 *************
-pypromice can installed using pip:
+The latest release of pypromice can installed using pip:
+
+.. code:: console
+
+	$ pip install pypromice
+
+For the most up-to-date version, pypromice can be installed directly from the repo: 
 
 .. code:: console
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setuptools.setup(
     description="PROMICE/GC-Net data processing toolbox",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/GEUS-Glaciology-and-Climate/PROMICE-AWS-processing",
+    url="https://github.com/GEUS-Glaciology-and-Climate/pypromice",
     project_urls={
         "Bug Tracker": "https://github.com/GEUS-Glaciology-and-Climate/pypromice/issues",
         "Documentation": "https://pypromice.readthedocs.io",


### PR DESCRIPTION
This PR is for pypi building of the `pypromice` package, including:

- Updated documentation
- A Github Action which should build and publish pypi package automatically when a new release of `pypromice` is made from this repo

I have also begun exploring pypromice distribution as a `conda-forge` package, however, this requires some coordination with `pydataverse`, one of our dependencies. See open issue [here](https://github.com/gdcc/pyDataverse/issues/159) for more details.