### PR TITLE
Fixing tundra processing variable writing and wrong negative longitudes

### DIFF
--- a/src/pypromice/process/L0toL1.py
+++ b/src/pypromice/process/L0toL1.py
@@ -8,7 +8,7 @@ import xarray as xr
 import re
 
 
-def toL1(L0, vars_df, flag_file=None, T_0=273.15, tilt_threshold=-100):
+def toL1(L0, vars_df, T_0=273.15, tilt_threshold=-100):
     '''Process one Level 0 (L0) product to Level 1
 
     Parameters
@@ -17,8 +17,6 @@ def toL1(L0, vars_df, flag_file=None, T_0=273.15, tilt_threshold=-100):
         Level 0 dataset
     vars_df : pd.DataFrame
         Metadata dataframe
-    flag_file : str
-        Flag .csv file path for bad data
     T_0 : int
         Air temperature for sonic ranger adjustment
     tilt_threshold : int
@@ -91,9 +89,14 @@ def toL1(L0, vars_df, flag_file=None, T_0=273.15, tilt_threshold=-100):
     
     if hasattr(ds, 'bedrock'):                                                 # Fix tilt to zero if station is on bedrock
         if ds.attrs['bedrock']==True or ds.attrs['bedrock'].lower() in 'true':
+            ds.attrs['bedrock'] = True                                         # ensures all AWS objects have a 'bedrock' attribute
             ds['tilt_x'] = (('time'), np.arange(ds['time'].size)*0)
             ds['tilt_y'] = (('time'), np.arange(ds['time'].size)*0)
-            
+        else:
+            ds.attrs['bedrock'] = False                                        # ensures all AWS objects have a 'bedrock' attribute
+    else:
+        ds.attrs['bedrock'] = False                                            # ensures all AWS objects have a 'bedrock' attribute
+
     ds['wdir_u'] = ds['wdir_u'].where(ds['wspd_u'] != 0)                       # Get directional wind speed                    
     ds['wspd_x_u'], ds['wspd_y_u'] = calcWindDir(ds['wspd_u'], ds['wdir_u']) 
     

--- a/src/pypromice/process/L1toL2.py
+++ b/src/pypromice/process/L1toL2.py
@@ -27,9 +27,9 @@ def toL2(L1, T_0=273.15, ews=1013.246, ei0=6.1071, eps_overcast=1.,
         default is 6.1071.
     eps_overcast : int, optional
         Cloud overcast. The default is 1..
-    eps_clear : int, optional
+    eps_clear : float, optional
         Cloud clear. The default is 9.36508e-6.
-    emissivity : int, optional
+    emissivity : float, optional
         Emissivity. The default is 0.97.
 
     Returns

--- a/src/pypromice/process/L1toL2.py
+++ b/src/pypromice/process/L1toL2.py
@@ -52,10 +52,11 @@ def toL2(L1, T_0=273.15, ews=1013.246, ei0=6.1071, eps_overcast=1.,
         
     # Determiune cloud cover for on-ice stations
     if not ds.attrs['bedrock']:
-        cc = calcCloudCoverage(ds['t_u'], T_0, eps_overcast, eps_clear,    # Calculate cloud coverage
+        cc = calcCloudCoverage(ds['t_u'], T_0, eps_overcast, eps_clear,        # Calculate cloud coverage
                                ds['dlr'], ds.attrs['station_id'])  
         ds['cc'] = (('time'), cc.data)
     else:
+        # Default cloud cover for bedrock station for which tilt should be 0 anyway.
         cc = 0.8
     
     # Determine surface temperature

--- a/src/pypromice/process/L1toL2.py
+++ b/src/pypromice/process/L1toL2.py
@@ -55,6 +55,8 @@ def toL2(L1, T_0=273.15, ews=1013.246, ei0=6.1071, eps_overcast=1.,
         cc = calcCloudCoverage(ds['t_u'], T_0, eps_overcast, eps_clear,    # Calculate cloud coverage
                                ds['dlr'], ds.attrs['station_id'])  
         ds['cc'] = (('time'), cc.data)
+    else:
+        cc = 0.8
     
     # Determine surface temperature
     ds['t_surf'] = calcSurfaceTemperature(T_0, ds['ulr'], ds['dlr'],           # Calculate surface temperature

--- a/src/pypromice/process/L2toL3.py
+++ b/src/pypromice/process/L2toL3.py
@@ -45,15 +45,16 @@ def toL3(L2, T_0=273.15, z_0=0.001, R_d=287.05, eps=0.622, es_0=6.1071,
     rho_atm_u = 100 * p_h_u / R_d / (T_h_u + T_0)                              # Calculate atmospheric density                                  
     nu_u = calcVisc(T_h_u, T_0, rho_atm_u)                                     # Calculate kinematic viscosity  
     q_h_u = calcHumid(T_0, T_100, T_h_u, es_0, es_100, eps,                    # Calculate specific humidity
-                       p_h_u, RH_cor_h_u)          
-    SHF_h_u, LHF_h_u= calcHeatFlux(T_0, T_h_u, Tsurf_h, rho_atm_u, WS_h_u,     # Calculate latent and sensible heat fluxes
-                                    z_WS_u, z_T_u, nu_u, q_h_u, p_h_u)     
-    SHF_h_u, LHF_h_u = cleanHeatFlux(SHF_h_u, LHF_h_u, T_h_u, Tsurf_h, p_h_u,  # Clean heat flux values
-                                      WS_h_u, RH_cor_h_u, ds['z_boom_u'])
+                       p_h_u, RH_cor_h_u)   
+    if not ds.attrs['bedrock']:       
+        SHF_h_u, LHF_h_u= calcHeatFlux(T_0, T_h_u, Tsurf_h, rho_atm_u, WS_h_u,     # Calculate latent and sensible heat fluxes
+                                        z_WS_u, z_T_u, nu_u, q_h_u, p_h_u)     
+        SHF_h_u, LHF_h_u = cleanHeatFlux(SHF_h_u, LHF_h_u, T_h_u, Tsurf_h, p_h_u,  # Clean heat flux values
+                                          WS_h_u, RH_cor_h_u, ds['z_boom_u'])
+        ds['dshf_u'] = (('time'), SHF_h_u.data)
+        ds['dlhf_u'] = (('time'), LHF_h_u.data)
     q_h_u = 1000 * q_h_u                                                       # Convert sp.humid from kg/kg to g/kg
     q_h_u = cleanSpHumid(q_h_u, T_h_u, Tsurf_h, p_h_u, RH_cor_h_u)             # Clean sp.humid values    
-    ds['dshf_u'] = (('time'), SHF_h_u.data)
-    ds['dlhf_u'] = (('time'), LHF_h_u.data)
     ds['qh_u'] = (('time'), q_h_u.data)    
 
     # Lower boom bulk calculation
@@ -70,15 +71,16 @@ def toL3(L2, T_0=273.15, z_0=0.001, R_d=287.05, eps=0.622, es_0=6.1071,
         rho_atm_l = 100 * p_h_l / R_d / (T_h_l + T_0)                          # Calculate atmospheric density                                  
         nu_l = calcVisc(T_h_l, T_0, rho_atm_l)                                 # Calculate kinematic viscosity  
         q_h_l = calcHumid(T_0, T_100, T_h_l, es_0, es_100, eps,                # Calculate sp.humidity
-                           p_h_l, RH_cor_h_l)        
-        SHF_h_l, LHF_h_l= calcHeatFlux(T_0, T_h_l, Tsurf_h, rho_atm_l, WS_h_l, # Calculate latent and sensible heat fluxes 
-                                        z_WS_l, z_T_l, nu_l, q_h_l, p_h_l)        
-        SHF_h_l, LHF_h_l = cleanHeatFlux(SHF_h_l, LHF_h_l, T_h_l, Tsurf_h, p_h_l, # Clean heat flux values
-                                          WS_h_l, RH_cor_h_l, ds['z_boom_l'])        
+                           p_h_l, RH_cor_h_l)
+        if not ds.attrs['bedrock']:       
+            SHF_h_l, LHF_h_l= calcHeatFlux(T_0, T_h_l, Tsurf_h, rho_atm_l, WS_h_l, # Calculate latent and sensible heat fluxes 
+                                            z_WS_l, z_T_l, nu_l, q_h_l, p_h_l)        
+            SHF_h_l, LHF_h_l = cleanHeatFlux(SHF_h_l, LHF_h_l, T_h_l, Tsurf_h, p_h_l, # Clean heat flux values
+                                              WS_h_l, RH_cor_h_l, ds['z_boom_l'])
+            ds['dshf_l'] = (('time'), SHF_h_l.data)
+            ds['dlhf_l'] = (('time'), LHF_h_l.data)
         q_h_l = 1000 * q_h_l                                                   # Convert sp.humid from kg/kg to g/kg
         q_h_l = cleanSpHumid(q_h_l, T_h_l, Tsurf_h, p_h_l, RH_cor_h_l)         # Clean sp.humid values
-        ds['dshf_l'] = (('time'), SHF_h_l.data)
-        ds['dlhf_l'] = (('time'), LHF_h_l.data)
         ds['qh_l'] = (('time'), q_h_l.data)    
 
     # if hasattr(ds, 'wspd_x_i'): 

--- a/src/pypromice/process/L2toL3.py
+++ b/src/pypromice/process/L2toL3.py
@@ -194,10 +194,12 @@ def calcHeatFlux(T_0, T_h, Tsurf_h, rho_atm, WS_h, z_WS, z_T, nu, q_h, p_h,
     LHF_h = xr.zeros_like(T_h)
     L = xr.full_like(T_h, 1E5)
     
-    u_star = kappa * WS_h / np.log(z_WS / z_0)                                 # Rough surfaces, from Smeets & Van den Broeke 2008
+    u_star = kappa * WS_h.where(WS_h>0) / np.log(z_WS / z_0)                                 # Rough surfaces, from Smeets & Van den Broeke 2008
     Re = u_star * z_0 / nu
-    z_0h = z_0 * np.exp(1.5 - 0.2 * np.log(Re) - 0.11 * np.log(Re)**2)
-    z_0h[WS_h <= 0] = 1e-10
+    z_0h = u_star
+    z_0h = xr.where(WS_h <= 0,
+                    1e-10,
+                    z_0* np.exp(1.5 - 0.2 * np.log(Re) - 0.11 * np.log(Re)**2))
     es_ice_surf = 10**(-9.09718
                        * (T_0 / (Tsurf_h + T_0) -1) - 3.56654
                        * np.log10(T_0 / (Tsurf_h + T_0)) + 0.876793

--- a/src/pypromice/process/aws.py
+++ b/src/pypromice/process/aws.py
@@ -435,6 +435,8 @@ def writeNC(outfile, Lx, col_names=None):
         os.remove(outfile)
     if col_names is not None:   
         names = [c for c in col_names if c in list(Lx.keys())]
+    else:
+        names = list(Lx.keys())
     Lx[names].to_netcdf(outfile, mode='w', format='NETCDF4', compute=True)    
     
 def writeAll(outpath, station_id, l3_h, l3_d, l3_m, csv_order=None):

--- a/src/pypromice/process/aws.py
+++ b/src/pypromice/process/aws.py
@@ -638,7 +638,6 @@ def addVars(ds, variables):
    '''
     for k in ds.keys():
         if k not in variables.index: continue
-        if "skip_processing" in variables.loc[k]['comment']: continue
         ds[k].attrs['standard_name'] = variables.loc[k]['standard_name']
         ds[k].attrs['long_name'] = variables.loc[k]['long_name']
         ds[k].attrs['units'] = variables.loc[k]['units']

--- a/src/pypromice/process/aws.py
+++ b/src/pypromice/process/aws.py
@@ -817,8 +817,8 @@ def resampleL3(ds_h, t):
     # recalculating wind direction from averaged directional wind speeds
     for var in ['wdir_u','wdir_l','wdir_i']:
         if var in df_d.columns:
-            df_d[var] = _calcWindDir(df_d['wspd_x'+var.split('_')[1]],
-                                   df_d['wspd_y'+var.split('_')[1]])
+            df_d[var] = _calcWindDir(df_d['wspd_x_'+var.split('_')[1]],
+                                   df_d['wspd_y_'+var.split('_')[1]])
     vals = [xr.DataArray(data=df_d[c], dims=['time'], 
            coords={'time':df_d.index}, attrs=ds_h[c].attrs) for c in df_d.columns]
     ds_d = xr.Dataset(dict(zip(df_d.columns,vals)), attrs=ds_h.attrs)  

--- a/src/pypromice/process/aws.py
+++ b/src/pypromice/process/aws.py
@@ -44,8 +44,8 @@ class AWS(object):
             Metadata info file path. If not given then pypromice's 
             metadata file is used. The default is None.
         '''
-        assert(os.path.isfile(config_file))
-        assert(os.path.isdir(inpath))
+        assert(os.path.isfile(config_file)), "cannot find "+config_file
+        assert(os.path.isdir(inpath)), "cannot find "+inpath
         print('\nAWS object initialising...')
         
         # Load config, variables CSF standards, and L0 files
@@ -301,7 +301,7 @@ def getConfig(config_file, inpath):
                                                                                # should carry all properties with it
     for k in conf.keys():                                                      # Check required fields are present
         for field in ["columns", "station_id", "format", "skiprows"]:
-            assert(field in conf[k].keys())
+            assert(field in conf[k].keys()), field+" not in config keys"
     return conf
 
 def getL0(infile, nodata, cols, skiprows, file_version, 

--- a/src/pypromice/process/aws.py
+++ b/src/pypromice/process/aws.py
@@ -638,6 +638,7 @@ def addVars(ds, variables):
    '''
     for k in ds.keys():
         if k not in variables.index: continue
+        if "skip_processing" in variables.loc[k]['comment']: continue
         ds[k].attrs['standard_name'] = variables.loc[k]['standard_name']
         ds[k].attrs['long_name'] = variables.loc[k]['long_name']
         ds[k].attrs['units'] = variables.loc[k]['units']

--- a/src/pypromice/process/aws.py
+++ b/src/pypromice/process/aws.py
@@ -119,7 +119,8 @@ class AWS(object):
         # Switch gps_lon to negative (degrees_east)
         # Do this here, and NOT in addMeta, otherwise we switch back to positive
         # when calling getMeta in joinL3! PJW
-        self.L3['gps_lon'] = self.L3['gps_lon'] * -1
+        if self.attrs['station_id'] not in ['UWN', 'Roof_GEUS', 'Roof_PROMICE']:
+            self.L3['gps_lon'] = self.L3['gps_lon'] * -1
 
         # Add variable attributes and metadata
         self.L3 = self.addAttributes(self.L3)

--- a/src/pypromice/process/aws.py
+++ b/src/pypromice/process/aws.py
@@ -817,8 +817,11 @@ def resampleL3(ds_h, t):
     # recalculating wind direction from averaged directional wind speeds
     for var in ['wdir_u','wdir_l','wdir_i']:
         if var in df_d.columns:
-            df_d[var] = _calcWindDir(df_d['wspd_x_'+var.split('_')[1]],
+            if ('wspd_x_'+var.split('_')[1] in df_d.columns) & ('wspd_x_'+var.split('_')[1] in df_d.columns):
+                df_d[var] = _calcWindDir(df_d['wspd_x_'+var.split('_')[1]],
                                    df_d['wspd_y_'+var.split('_')[1]])
+            else:
+                print(var,'in dataframe but not','wspd_x_'+var.split('_')[1],'wspd_x_'+var.split('_')[1])
     vals = [xr.DataArray(data=df_d[c], dims=['time'], 
            coords={'time':df_d.index}, attrs=ds_h[c].attrs) for c in df_d.columns]
     ds_d = xr.Dataset(dict(zip(df_d.columns,vals)), attrs=ds_h.attrs)  

--- a/src/pypromice/process/aws.py
+++ b/src/pypromice/process/aws.py
@@ -352,6 +352,13 @@ def getL0(infile, nodata, cols, skiprows, file_version,
                          skip_blank_lines=True,
                          usecols=range(len(cols)),
                          low_memory=False)
+        try:
+            df.index = pd.to_datetime(df.index)
+        except  ValueError as e:
+            print(e)
+            print('Trying pd.to_datetime with format=mixed')
+            df.index = pd.to_datetime(df.index, format='mixed')
+            
 
     # Drop SKIP columns
     for c in df.columns:

--- a/src/pypromice/process/aws.py
+++ b/src/pypromice/process/aws.py
@@ -119,7 +119,7 @@ class AWS(object):
         # Switch gps_lon to negative (degrees_east)
         # Do this here, and NOT in addMeta, otherwise we switch back to positive
         # when calling getMeta in joinL3! PJW
-        if self.attrs['station_id'] not in ['UWN', 'Roof_GEUS', 'Roof_PROMICE']:
+        if self.L3.attrs['station_id'] not in ['UWN', 'Roof_GEUS', 'Roof_PROMICE']:
             self.L3['gps_lon'] = self.L3['gps_lon'] * -1
 
         # Add variable attributes and metadata

--- a/src/pypromice/process/variables.csv
+++ b/src/pypromice/process/variables.csv
@@ -36,7 +36,7 @@ dshf_l,surface_downward_sensible_heat_flux,Sensible heat flux (lower boom),W m-2
 z_boom_u,distance_to_surface_from_boom,Upper boom height,m,0.3,10,dshf_u dlhf_u qh_u,all,all,4,physicalMeasurement,time lat lon alt,True,
 z_boom_q_u,distance_to_surface_from_boom_quality,Upper boom height (quality),-,,,,all,,4,qualityInformation,time lat lon alt,True,L0 only
 z_boom_l,distance_to_surface_from_boom,Lower boom height,m,0.3,5,dshf_l dlhf_l qh_l,two-boom,all,4,physicalMeasurement,time lat lon alt,True,
-z_boom_q_l,distance_to_surface_from_boom_quality,Loer boom height (quality),-,,,,two-boom,,4,qualityInformation,time lat lon alt,True,L0 only
+z_boom_q_l,distance_to_surface_from_boom_quality,Lower boom height (quality),-,,,,two-boom,,4,qualityInformation,time lat lon alt,True,L0 only
 z_stake,distance_to_surface_from_stake_assembly,Stake height,m,0.3,8,,one-boom,all,4,physicalMeasurement,time lat lon alt,True,HeightStakes(m)
 z_stake_q,distance_to_surface_from_stake_assembly_quality,Stake height (quality),-,,,,one-boom,,4,qualityInformation,time lat lon alt,True,L0 only
 z_pt,depth_of_pressure_transducer_in_ice,Depth of pressure transducer in ice,m,0,30,z_pt_cor,one-boom,all,4,physicalMeasurement,time lat lon alt,False,DepthPressureTransducer(m)
@@ -66,7 +66,7 @@ gps_lon,gps_longitude,Longitude,degrees_east,5,70,,all,all,6,coordinate,time lat
 gps_alt,gps_altitude,Altitude,m,0,3000,,all,all,2,coordinate,time lat lon alt,True,
 gps_time,gps_time,GPS time,s,0,240000,,all,all,,coordinate,time lat lon alt,True,
 gps_geoid,gps_geoid_separation,Height of EGM96 geoid over WGS84 ellipsoid,m,,,,one-boom,all,,physicalMeasurement,time lat lon alt,True,
-gps_geounit,gps_geounit,GeoUnit,-,,,,all,raw,,qualityInformation,time lat lon alt,True,
+gps_geounit,gps_geounit,GeoUnit,-,,,,all,,,qualityInformation,time lat lon alt,True,L0 only
 gps_hdop,gps_hdop,GPS horizontal dillution of precision (HDOP),m,,,,all,all,2,qualityInformation,time lat lon alt,True,NMEA: Horizontal dilution of precision
 gps_numsat,gps_numsat,GPS number of satellites,-,,,,one-boom,all,0,qualityInformation,time lat lon alt,True,
 gps_q,gps_q,Quality,-,,,,one-boom,all,,qualityInformation,time lat lon alt,True,

--- a/src/pypromice/process/variables.csv
+++ b/src/pypromice/process/variables.csv
@@ -66,7 +66,7 @@ gps_lon,gps_longitude,Longitude,degrees_east,5,70,,all,all,6,coordinate,time lat
 gps_alt,gps_altitude,Altitude,m,0,3000,,all,all,2,coordinate,time lat lon alt,True,
 gps_time,gps_time,GPS time,s,0,240000,,all,all,,coordinate,time lat lon alt,True,
 gps_geoid,gps_geoid_separation,Height of EGM96 geoid over WGS84 ellipsoid,m,,,,one-boom,all,,physicalMeasurement,time lat lon alt,True,
-gps_geounit,gps_geounit,GeoUnit,-,,,,all,raw,,qualityInformation,time lat lon alt,True,skip_processing
+gps_geounit,gps_geounit,GeoUnit,-,,,,all,raw,,qualityInformation,time lat lon alt,True,
 gps_hdop,gps_hdop,GPS horizontal dillution of precision (HDOP),m,,,,all,all,2,qualityInformation,time lat lon alt,True,NMEA: Horizontal dilution of precision
 gps_numsat,gps_numsat,GPS number of satellites,-,,,,one-boom,all,0,qualityInformation,time lat lon alt,True,
 gps_q,gps_q,Quality,-,,,,one-boom,all,,qualityInformation,time lat lon alt,True,

--- a/src/pypromice/process/variables.csv
+++ b/src/pypromice/process/variables.csv
@@ -16,10 +16,10 @@ wspd_l,wind_speed,Wind speed (lower boom),m s-1,0,100,"wdir_l wspd_x_l wspd_y_l 
 wdir_u,wind_from_direction,Wind from direction (upper boom),degrees,1,360,wspd_x_u wspd_y_u,all,all,4,physicalMeasurement,time lat lon alt,False,
 wdir_std_u,wind_from_direction_standard_deviation,Wind from direction (standard deviation),degrees,,,,one-boom,,4,qualityInformation,time lat lon alt,False,L0 only
 wdir_l,wind_from_direction,Wind from direction (lower boom),degrees,1,360,wspd_x_l wspd_y_l,two-boom,all,4,physicalMeasurement,time lat lon alt,False,
-wspd_x_u,wind_speed_from_x_direction,Wind speed from x direction (upper boom),m s-1,-100,100,wdir_u wspd_u,all,,4,modelResult,time lat lon alt,False,L0 only
-wspd_y_u,wind_speed_from_y_direction,Wind speed from y direction (upper boom),m s-1,-100,100,wdir_u wspd_u,all,,4,modelResult,time lat lon alt,False,L0 only
-wspd_x_l,wind_speed_from_x_direction,Wind speed from x direction (lower boom),m s-1,-100,100,wdir_l wspd_l,two-boom,,4,modelResult,time lat lon alt,False,L0 only
-wspd_y_l,wind_speed_from_y_direction,Wind speed from y direction (lower boom),m s-1,-100,100,wdir_l wspd_l,two-boom,,4,modelResult,time lat lon alt,False,L0 only
+wspd_x_u,wind_speed_from_x_direction,Wind speed from x direction (upper boom),m s-1,-100,100,wdir_u wspd_u,all,all,4,modelResult,time lat lon alt,False,L0 only
+wspd_y_u,wind_speed_from_y_direction,Wind speed from y direction (upper boom),m s-1,-100,100,wdir_u wspd_u,all,all,4,modelResult,time lat lon alt,False,L0 only
+wspd_x_l,wind_speed_from_x_direction,Wind speed from x direction (lower boom),m s-1,-100,100,wdir_l wspd_l,two-boom,all,4,modelResult,time lat lon alt,False,L0 only
+wspd_y_l,wind_speed_from_y_direction,Wind speed from y direction (lower boom),m s-1,-100,100,wdir_l wspd_l,two-boom,all,4,modelResult,time lat lon alt,False,L0 only
 dsr,surface_downwelling_shortwave_flux,Downwelling shortwave radiation,W m-2,-10,1500,albedo dsr_cor usr_cor,all,all,4,physicalMeasurement,time lat lon alt,False,"Actually radiation_at_sensor, not flux. Units 1E-5 V. Engineering units."
 dsr_cor,surface_downwelling_shortwave_flux_corrected,Downwelling shortwave radiation - corrected,W m-2,,,,all,all,4,modelResult,time lat lon alt,False,Derived value (L2 or later)
 usr,surface_upwelling_shortwave_flux,Upwelling shortwave radiation,W m-2,-10,1000,albedo dsr_cor usr_cor,all,all,4,physicalMeasurement,time lat lon alt,False,
@@ -43,10 +43,10 @@ z_pt,depth_of_pressure_transducer_in_ice,Depth of pressure transducer in ice,m,0
 z_pt_cor,depth_of_pressure_transducer_in_ice_corrected,Depth of pressure transducer in ice - corrected,m,0,30,,one-boom,all,4,modelResult,time lat lon alt,False,Derived value (L2 or later)
 precip_u,precipitation,Precipitation (upper boom) (cumulative solid & liquid),mm,0,,precip_u_cor precip_u_rate,all,all,4,physicalMeasurement,time lat lon alt,True,Without wind/undercatch correction
 precip_u_cor,precipitation_corrected,Precipitation (upper boom) (cumulative solid & liquid) – corrected,mm,0,,,all,all,4,modelResult,time lat lon alt,True,With wind/undercatch correction
-precip_u_rate,precipitation_rate,Precipitation rate (upper boom) (cumulative solid & liquid) – corrected,mm,0,,,all,,4,modelResult,time lat lon alt,True,L0 only
+precip_u_rate,precipitation_rate,Precipitation rate (upper boom) (cumulative solid & liquid) – corrected,mm,0,,,all,all,4,modelResult,time lat lon alt,True,L0 only
 precip_l,precipitation,Precipitation (lower boom) (cumulative solid & liquid),mm,0,,precip_l_cor precip_l_rate,two-boom,all,4,physicalMeasurement,time lat lon alt,True,Without wind/undercatch correction
 precip_l_cor,precipitation_corrected,Precipitation (lower boom) (cumulative solid & liquid) – corrected,mm,0,,,two-boom,all,4,modelResult,time lat lon alt,True,With wind/undercatch correction
-precip_l_rate,precipitation_rate,Precipitation rate (lower boom) (cumulative solid & liquid) – corrected,mm,0,,,two-boom,,4,modelResult,time lat lon alt,True,L0 only
+precip_l_rate,precipitation_rate,Precipitation rate (lower boom) (cumulative solid & liquid) – corrected,mm,0,,,two-boom,all,4,modelResult,time lat lon alt,True,L0 only
 t_i_1,ice_temperature_at_t1,Ice temperature at sensor 1,degrees_C,-80,40,,all,all,4,physicalMeasurement,time lat lon alt,False,t1 is installed @ 1 m depth
 t_i_2,ice_temperature_at_t2,Ice temperature at sensor 2,degrees_C,-80,40,,all,all,4,physicalMeasurement,time lat lon alt,False,
 t_i_3,ice_temperature_at_t3,Ice temperature at sensor 3,degrees_C,-80,40,,all,all,4,physicalMeasurement,time lat lon alt,False,
@@ -87,8 +87,8 @@ rh_i,relative_humidity,Relative humidity (instantaneous),%,0,150,rh_i_cor,all,TX
 rh_i_cor,relative_humidity_corrected,Relative humidity (instantaneous) – corrected,%,0,100,,all,TX,4,modelResult,time lat lon alt,True,For meteorological observations
 wspd_i,wind_speed,Wind speed (instantaneous),m s-1,0,100,wdir_i wspd_x_i wspd_y_i,all,TX,4,physicalMeasurement,time lat lon alt,True,For meteorological observations
 wdir_i,wind_from_direction,Wind from direction (instantaneous),degrees,1,360,wspd_x_i wspd_y_i,all,TX,4,physicalMeasurement,time lat lon alt,True,For meteorological observations
-wspd_x_i,wind_speed_from_x_direction,Wind speed from x direction (instantaneous),m s-1,-100,100,wdir_i wspd_i,all,,4,modelResult,time lat lon alt,True,For meteorological observations
-wspd_y_i,wind_speed_from_y_direction,Wind speed from y direction (instantaneous),m s-1,-100,100,wdir_i wspd_i,all,,4,modelResult,time lat lon alt,True,For meteorological observations
+wspd_x_i,wind_speed_from_x_direction,Wind speed from x direction (instantaneous),m s-1,-100,100,wdir_i wspd_i,all,TX,4,modelResult,time lat lon alt,True,For meteorological observations
+wspd_y_i,wind_speed_from_y_direction,Wind speed from y direction (instantaneous),m s-1,-100,100,wdir_i wspd_i,all,TX,4,modelResult,time lat lon alt,True,For meteorological observations
 msg_i,message,Message string (instantaneous),-,,,,all,TX,,qualityInformation,time lat lon alt,True,For meteorological observations
 msg_lat,message_latitude,latitude from modem (email text),degrees_north,50,83,,all,all,6,coordinate,time lat lon alt,True,
 msg_lon,message_longitude,longitude from modem (email text),degrees_east,-72,13,,all,all,6,coordinate,time lat lon alt,True,

--- a/src/pypromice/process/variables.csv
+++ b/src/pypromice/process/variables.csv
@@ -66,7 +66,7 @@ gps_lon,gps_longitude,Longitude,degrees_east,5,70,,all,all,6,coordinate,time lat
 gps_alt,gps_altitude,Altitude,m,0,3000,,all,all,2,coordinate,time lat lon alt,True,
 gps_time,gps_time,GPS time,s,0,240000,,all,all,,coordinate,time lat lon alt,True,
 gps_geoid,gps_geoid_separation,Height of EGM96 geoid over WGS84 ellipsoid,m,,,,one-boom,all,,physicalMeasurement,time lat lon alt,True,
-gps_geounit,gps_geounit,GeoUnit,-,,,,all,raw,,qualityInformation,time lat lon alt,True,
+gps_geounit,gps_geounit,GeoUnit,-,,,,all,raw,,qualityInformation,time lat lon alt,True,skip_processing
 gps_hdop,gps_hdop,GPS horizontal dillution of precision (HDOP),m,,,,all,all,2,qualityInformation,time lat lon alt,True,NMEA: Horizontal dilution of precision
 gps_numsat,gps_numsat,GPS number of satellites,-,,,,one-boom,all,0,qualityInformation,time lat lon alt,True,
 gps_q,gps_q,Quality,-,,,,one-boom,all,,qualityInformation,time lat lon alt,True,


### PR DESCRIPTION
Many improvements. 

The main one being:
- the removal of unnecessary variables and filters on bedrock stations

Note that [added a "skip_processing" key word in "comment" column of "variable.csv"](https://github.com/GEUS-Glaciology-and-Climate/pypromice/pull/172/commits/041b033fd27782732d3e2e4af799aa64f5e91868) was a first idea of a variable-specific processing switch, but it was reverted and the "bedrock" attribute defined in the config files (False if not defined) is used instead to decide if some variables shoud be skipped.

- harmonizing variables in the csv and netcdf
- moving the directional wind speed and making its calculation fail-safe (described in commit)
- some small changes to stop log(0) warnings or pd.read_csv date_parser deprecation warnings or to make assert errors more instructive
