### PR TITLE
Fixing typo in aws write and removing unused variables

### DIFF
--- a/src/pypromice/process/aws.py
+++ b/src/pypromice/process/aws.py
@@ -627,7 +627,7 @@ def getColNames(vars_df, booms=None, data_type=None, bedrock=False):
         vars_df = vars_df.loc[vars_df['data_type'].isin(['raw','all'])]
     
     col_names = list(vars_df.index)
-    if bedrock:
+    if (bedrock == True) | (bedrock.lower() == 'true'):
         col_names.remove('cc')
         for v in ['dlhf_u', 'dlhf_l', 'dshf_u', 'dshf_l']:
             try:

--- a/src/pypromice/process/aws.py
+++ b/src/pypromice/process/aws.py
@@ -627,7 +627,9 @@ def getColNames(vars_df, booms=None, data_type=None, bedrock=False):
         vars_df = vars_df.loc[vars_df['data_type'].isin(['raw','all'])]
     
     col_names = list(vars_df.index)
-    if (bedrock == True) | (bedrock.lower() == 'true'):
+	if isinstance(bedrock, str):
+		bedrock = (bedrock.lower() == 'true')
+    if bedrock == True:
         col_names.remove('cc')
         for v in ['dlhf_u', 'dlhf_l', 'dshf_u', 'dshf_l']:
             try:

--- a/src/pypromice/process/aws.py
+++ b/src/pypromice/process/aws.py
@@ -627,8 +627,8 @@ def getColNames(vars_df, booms=None, data_type=None, bedrock=False):
         vars_df = vars_df.loc[vars_df['data_type'].isin(['raw','all'])]
     
     col_names = list(vars_df.index)
-	if isinstance(bedrock, str):
-		bedrock = (bedrock.lower() == 'true')
+    if isinstance(bedrock, str):
+        bedrock = (bedrock.lower() == 'true')
     if bedrock == True:
         col_names.remove('cc')
         for v in ['dlhf_u', 'dlhf_l', 'dshf_u', 'dshf_l']:

--- a/src/pypromice/process/variables.csv
+++ b/src/pypromice/process/variables.csv
@@ -68,17 +68,17 @@ gps_time,gps_time,GPS time,s,0,240000,,all,all,,coordinate,time lat lon alt,True
 gps_geoid,gps_geoid_separation,Height of EGM96 geoid over WGS84 ellipsoid,m,,,,one-boom,all,,physicalMeasurement,time lat lon alt,True,
 gps_geounit,gps_geounit,GeoUnit,-,,,,all,,,qualityInformation,time lat lon alt,True,L0 only
 gps_hdop,gps_hdop,GPS horizontal dillution of precision (HDOP),m,,,,all,all,2,qualityInformation,time lat lon alt,True,NMEA: Horizontal dilution of precision
-gps_numsat,gps_numsat,GPS number of satellites,-,,,,one-boom,all,0,qualityInformation,time lat lon alt,True,
-gps_q,gps_q,Quality,-,,,,one-boom,all,,qualityInformation,time lat lon alt,True,
+gps_numsat,gps_numsat,GPS number of satellites,-,,,,,all,0,qualityInformation,time lat lon alt,True,L0 only
+gps_q,gps_q,Quality,-,,,,,all,,qualityInformation,time lat lon alt,True,L0 only
 lat,gps_mean_latitude,GPS mean latitude (from all time-series),degrees,,,,all,,6,modelResult,time lat lon alt,True,
 lon,gps_mean_longitude,GPS mean longitude (from all time-series),degrees,,,,all,,6,modelResult,time lat lon alt,True,
 alt,gps_mean_altitude,GPS mean altitude (from all time-series),degrees,,,,all,,6,modelResult,time lat lon alt,True,
 batt_v,battery_voltage,Battery voltage,V,0,30,,all,all,2,physicalMeasurement,time lat lon alt,True,
-batt_v_ini,,,-,0,30,,one-boom,all,2,physicalMeasurement,time lat lon alt,True,
-batt_v_ss,battery_voltage_at_sample_start,Battery voltage (sample start),V,0,30,,one-boom,all,2,physicalMeasurement,time lat lon alt,True,
+batt_v_ini,,,-,0,30,,,all,2,physicalMeasurement,time lat lon alt,True,L0 only
+batt_v_ss,battery_voltage_at_sample_start,Battery voltage (sample start),V,0,30,,,all,2,physicalMeasurement,time lat lon alt,True,L0 only
 fan_dc_u,fan_current,Fan current (upper boom),mA,0,200,,all,all,2,physicalMeasurement,time lat lon alt,True,
 fan_dc_l,fan_current,Fan current (lower boom),mA,0,200,,two-boom,all,2,physicalMeasurement,time lat lon alt,True,
-freq_vw,frequency_of_precipitation_wire_vibration,Frequency of vibrating wire in precipitation gauge,Hz,0,10000,precip_u,one-boom,all,,physicalMeasurement,time lat lon alt,True,
+freq_vw,frequency_of_precipitation_wire_vibration,Frequency of vibrating wire in precipitation gauge,Hz,0,10000,precip_u,,all,,physicalMeasurement,time lat lon alt,True,L0 only
 t_log,temperature_of_logger,Logger temperature,degrees_C,-80,40,,one-boom,all,4,physicalMeasurement,time lat lon alt,True,LoggerTemperature(C)
 t_rad,temperature_of_radiation_sensor,Radiation sensor temperature,degrees_C,-80,40,t_surf dlr ulr,all,all,4,physicalMeasurement,time lat lon alt,False,
 p_i,air_pressure,Air pressure (instantaneous) minus 1000,hPa,-350,100,,all,TX,4,physicalMeasurement,time lat lon alt,True,For meteorological observations


### PR DESCRIPTION
- The attribute "bedrock" was saved as a string and not as a boolean. As a result cloud cover and THF were not written into files.
- Removing gps_numsat, gps_q, batt_v_ini, batt_v_ss, freq_vw from L3 product.

Tested on glacio01.

Needed before the next dataverse release.