### PR TITLE
Update use_v3 list in wmo_config.py

### DIFF
--- a/src/pypromice/postprocess/wmo_config.py
+++ b/src/pypromice/postprocess/wmo_config.py
@@ -17,7 +17,7 @@ stid_to_skip = { # All the following IDS will not be processed or submitted
     'discontinued': ['CEN1','TAS_U','QAS_A','NUK_N','THU_U','JAR','SWC'],
     'no_instantaneous': ['ZAK_L','ZAK_U','KAN_B'], # currently not transmitting instantaneous values
     'suspect_data': [], # instantaneous data is suspect
-    'use_v3': ['KPC_L','KPC_U','NUK_U','ZAK_L','ZAK_U','QAS_U','QAS_M','NUK_U','KAN_L'], # use v3 versions instead (but registered IDs are non-v3 names)
+    'use_v3': ['KPC_L','KPC_U','NUK_U','ZAK_L','ZAK_U','QAS_U','QAS_M','KAN_L'], # use v3 versions instead (but registered IDs are non-v3 names)
     'v3_bad': ['QAS_Lv3'] # QAS_Lv3 new ablation sensor & non-standard logger program. Must be addressed in field. Talk to RSF.
     # Eventually, as we change all stations to v3, the use_v3 list should be empty (there will not be v3 and non-v3 stations operating together)
     # If your remove a station from 'v3_bad', then add it to 'use_v3' if both v2 and v3 stations still exist together

--- a/src/pypromice/postprocess/wmo_config.py
+++ b/src/pypromice/postprocess/wmo_config.py
@@ -17,7 +17,7 @@ stid_to_skip = { # All the following IDS will not be processed or submitted
     'discontinued': ['CEN1','TAS_U','QAS_A','NUK_N','THU_U','JAR','SWC'],
     'no_instantaneous': ['ZAK_L','ZAK_U','KAN_B'], # currently not transmitting instantaneous values
     'suspect_data': [], # instantaneous data is suspect
-    'use_v3': ['KPC_L','KPC_U','NUK_U','ZAK_L','ZAK_U','QAS_U'], # use v3 versions instead (but registered IDs are non-v3 names)
+    'use_v3': ['KPC_L','KPC_U','NUK_U','ZAK_L','ZAK_U','QAS_U','QAS_M','NUK_U','KAN_L'], # use v3 versions instead (but registered IDs are non-v3 names)
     'v3_bad': ['QAS_Lv3'] # QAS_Lv3 new ablation sensor & non-standard logger program. Must be addressed in field. Talk to RSF.
     # Eventually, as we change all stations to v3, the use_v3 list should be empty (there will not be v3 and non-v3 stations operating together)
     # If your remove a station from 'v3_bad', then add it to 'use_v3' if both v2 and v3 stations still exist together


### PR DESCRIPTION
In response to Robert's email:

```
We made some updates to the PROMICE AWSs:

QAS_M decommissioned, replaced by QAS_Mv3
QAS_U decommissioned, but we have QAS_Uv3
NUK_U decommissioned, but we have NUK_Uv3
There is a new KAN_Lv3
```
All four of these stations should be in `stid_to_skip['use_v3']`.

For review, any station listed in `stid_to_skip` will be skipped in `getBUFR`. However, if we are processing a v3 station (e.g. `NUK_Uv3`) and the "base" station name (e.g. `NUK_U`) is listed in `stid_to_skip['use_v3']` then we will process the v3 station and strip the `v3` from the name so we are submitting to WMO with the registered non-v3 name.

The `discontinued` list is used for stations that have been discontinued and do not have a v3 and non-v3 version.

If @ladsmund will be maintaining the AWS processing and WMO BUFR generation moving forward, it is important to know about `wmo_config.py` and make sure it is periodically reviewed and maintained, particularly the `stid_to_skip` dict.