### PR TITLE
CITATION.cff file added

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,68 @@
+
+cff-version: 1.2.0
+title: pypromice
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file
+type: software
+authors:
+  - given-names: Penelope
+    family-names: How
+    email: pho@geus.dk
+    affiliation: GEUS
+    orcid: 'https://orcid.org/0000-0002-8088-8497'
+  - given-names: Mads Christian
+    family-names: Lund
+    email: maclu@geus.dk
+    affiliation: GEUS
+    orcid: 'https://orcid.org/0009-0009-0446-8253'
+  - given-names: Rasmus Bahbah
+    family-names: Nielsen
+    email: rabni@geus.dk
+    affiliation: GEUS
+    orcid: 'https://orcid.org/0000-0003-2342-639X'
+  - given-names: Andreas P.
+    family-names: Ahlstrøm
+    email: apa@geus.dk
+    affiliation: GEUS
+    orcid: 'https://orcid.org/0000-0001-8235-8070'
+  - given-names: Robert S.
+    email: rsf@geus.dk
+    family-names: Fausto
+    affiliation: GEUS
+    orcid: 'https://orcid.org/0000-0003-1317-8185'
+  - given-names: Signe Hillerup
+    family-names: Larsen
+    email: shl@geus.dk
+    affiliation: GEUS
+    orcid: 'https://orcid.org/0000-0002-3656-3521'
+  - given-names: Kenneth D.
+    family-names: Mankoff
+    email: mankoff@gmail.com
+    affiliation: NASA GISS
+    orcid: 'https://orcid.org/0000-0001-5453-2019'
+  - given-names: Baptiste
+    family-names: Vandecrux
+    email: bav@geus.dk
+    affiliation: GEUS
+    orcid: 'https://orcid.org/0000-0002-4169-8973'
+  - given-names: Patrick J.
+    family-names: Wright
+    orcid: 'https://orcid.org/0000-0003-2999-9076'
+    affiliation: Synoptic
+    email: pajwr@geus.dk
+identifiers:
+  - type: doi
+    value: 10.21105/joss.05298
+    description: JOSS software paper
+  - type: doi
+    value: 10.22008/FK2/3TSBF0
+    description: Dataverse for releases
+repository-code: 'https://github.com/GEUS-Glaciology-and-Climate/pypromice'
+url: 'https://pypromice.readthedocs.io/'
+keywords:
+  - weather
+  - weather-station
+  - greenland
+  - python
+license: GPL-2.0

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you intend to use PROMICE AWS data and/or pypromice in your work, please cite
 
 **How, P., Wright, P.J., Mankoff, K., Vandecrux, B., Fausto, R.S. and Ahlstrøm, A.P. (2023) pypromice: A Python package for processing automated weather station data, Journal of Open Source Software, 8(86), 5298, [https://doi.org/10.21105/joss.05298](https://doi.org/10.21105/joss.05298)** 
 
-**How, P., Wright, P.J., Mankoff, K., Vandecrux, B., Fausto, R.S. and Ahlstrøm, A.P. (2023) pypromice, GEUS Dataverse, [https://doi.org/10.22008/FK2/3TSBF0](https://doi.org/10.22008/FK2/3TSBF0)** 
+**How, P., Lund, M.C., Nielsen, R.B., Ahlstrøm, A.P., Fausto, R.S., Larsen, S.H., Mankoff, K.D., Vandecrux, B., Wright, P.J. (2023) pypromice, GEUS Dataverse, [https://doi.org/10.22008/FK2/3TSBF0](https://doi.org/10.22008/FK2/3TSBF0)** 
 
 ## Installation
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ Fausto, R.S., van As, D., Mankoff, K.D., Vandecrux, B., Citterio, M., Ahlstrøm,
 
 How, P., Wright, P.J., Mankoff, K., Vandecrux, B., Fausto, R.S. and Ahlstrøm, A.P. (2023) pypromice: A Python package for processing automated weather station data, Journal of Open Source Software, 8(86), 5298, https://doi.org/10.21105/joss.05298
 
-How, P., Wright, P.J., Mankoff, K., Vandecrux, B., Fausto, R.S. and Ahlstrøm, A.P. (2023) pypromice, GEUS Dataverse, https://doi.org/10.22008/FK2/3TSBF0
+How, P., Lund, M.C., Nielsen, R.B., Ahlstrøm, A.P., Fausto, R.S., Larsen, S.H., Mankoff, K.D., Vandecrux, B., Wright, P.J. (2023) pypromice, GEUS Dataverse, https://doi.org/10.22008/FK2/3TSBF0
 
 .. _pypromice: https://github.com/GEUS-Glaciology-and-Climate/pypromice
 .. _PROMICE: https://promice.dk


### PR DESCRIPTION
As pointed out by @mankoff in #187, citation prompts on repos are a handy and simple thing to implement.

The authorship follows the Dataverse entry for the most recent pypromice release, `v1.3.0`, which is also updated here in the repo readme and readthedocs page.