### PR TITLE
Action unit test and process test versions updated

### DIFF
--- a/.github/workflows/process_test.yml
+++ b/.github/workflows/process_test.yml
@@ -22,6 +22,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install wheel
+          python3 -m pip install --upgrade setuptools
           cd $GITHUB_WORKSPACE/main
           pip install .  
       - name: Clone AWS Level 0 data repo for testing

--- a/.github/workflows/process_test.yml
+++ b/.github/workflows/process_test.yml
@@ -9,11 +9,11 @@ jobs:
     name: process_test
     steps:
       - name: Install Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.8"        
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: "main"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -22,8 +22,9 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
-          python -m pip install --upgrade pip
-          pip install Bottleneck
+          python3 -m pip install --upgrade pip
+          python3 -m pip install Bottleneck 
+          python3 -m pip install --upgrade setuptools
           cd $GITHUB_WORKSPACE
           pip install . 
       - name: Run unit tests

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -12,11 +12,11 @@ jobs:
         python-version: ['3.8','3.9','3.10']
     steps:
       - name: Install Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.x"        
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install dependencies


### PR DESCRIPTION
This was raised by @BaptisteVandecrux in his latest PR #207 where the unit test was not working due to the `pkg_resources` package not being recognised.

I discovered the problem was with the Github Action itself - we are using an old version of the `checkout` and `setup-python` Actions, which have just been deprecated. So I have updated these in this PR. 

In addition, to make sure we don't have problems from this again, I have hard coded for the `setuptools` package to be upgraded during the Python setup step in each Action. This should mean that the `pkg_resources` package will be found for running the unit test and process test.

After this PR is merged with the main branch, then you should be able to run the Actions on your PR @BaptisteVandecrux. Then you should be able to continue with merging. 