### PR TITLE
Enable downloadable documentation with readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,6 +15,11 @@ build:
 sphinx:
   configuration: docs/conf.py
 
+# Build downloadable documentation files
+formats:
+  - pdf
+  - epub
+  
 # We recommend specifying your dependencies to enable reproducible builds:
 # https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:


### PR DESCRIPTION
This is so that we can auto-generate pdf and epub documentation from readthedocs. It looks like this: https://pypromice.readthedocs.io/_/downloads/en/v1.2.1/pdf/

We previously did this automatically, but it changed when readthedocs versioning had to be updated ( in #191). So we now have to specify pdf/epub builds in the readthedocs configuration file in the repo.