### PR TITLE
Range thresholding moved to earlier in L0toL1 processing

### DIFF
--- a/src/pypromice/process/L0toL1.py
+++ b/src/pypromice/process/L0toL1.py
@@ -36,6 +36,9 @@ def toL1(L0, vars_df, T_0=273.15, tilt_threshold=-100):
         if l not in ['time', 'msg_i', 'gps_lat', 'gps_lon', 'gps_alt', 'gps_time']:
             ds[l] = _reformatArray(ds[l])
 
+    #Perform range threshold before all corrections are applied
+    ds = clip_values(ds, vars_df)
+
     # ds['time_orig'] = ds['time'] # Not used
 
     # The following drops duplicate datetime indices. Needs to run before _addTimeShift!


### PR DESCRIPTION
Bug found where `z_boom_u`/`z_boom_l` measurements are jumping where `t_u`/`t_l` measurements are below -50.

This is because of an error in the lufft sensor that report bad readings below -50. Here is an example with station HUM:

```
In [1]: from pypromice.process import AWS
In [2]: aws = AWS('aws-l0/tx/config/HUM.toml', 'aws-l0/tx/')
In [3]: aws.process()

# Level 0 z_boom and t data (before processing)

In [4]: list(aws.L0[0]['z_boom_u'].sel(time='2022-11-09').values)
Out[4]: 
[3.965, 3.972, 3.974, 3.977, 3.984, 3.987, 3.991, 3.995,
 3.995, 3.987, 3.982, 3.984, 3.979, 3.978, 3.957, 3.95,
 3.937, 3.937, 3.927, 3.924, 3.92, 3.914, 3.916, 3.919]

In [5]: list(aws.L0[0]['t_u'].sel(time='2022-11-09').values)
Out[5]: 
[-49.0, 650.0, 1000.0, 1000.0, 1000.0, 1000.0, 1000.0, 825.0, 
-49.95, 125.0, 825.0, 300.7, -48.58, -49.28, -48.55, -47.2, 
-46.22, -45.37, -44.85, -44.15, -43.7, -43.23, -43.02, -42.93]

# Level 1 z_boom data (after processing, with erroneous jumps)

In [6]: list(aws.L1[0]['z_boom_u'].sel(time='2022-11-09').values)
Out[6]: 
[7.289180861917533, 8.57528227190415, 8.579600138103498, 8.586076937402519, 
 8.601189469100236, 8.607666268399257, 8.002247110305188,
 3.6112975758332504, 4.823247426546757, 7.994226817536152, 5.7716481286699075,
 3.6123897126299003, 3.602228735667318, 3.6071902823546296, 3.5989152582748902,
 3.600331164726147, 3.5951962880115276, 3.599297693561251, 3.595655208111283,
 3.596436753864435, 3.5964484525318636, 3.592583224465607, 3.5951217748425828,
 3.599047862357614]
```

I found a simple solution for this is to run the range thresholding QC at the beginning of `pypromice.process.L0toL1`. Right now, this is only done at the end of  `pypromice.process.L0toL1` AFTER `z_boom_u`/`z_boom_l` is corrected for with `t_u`/`t_l`. 

Instead, we should perform the range threshold at the beginning of `pypromice.process.L0toL1`. This removes errors in the temperature data before applying them to correct the boom height.

```
In [7]: list(aws.L1[0]['z_boom_u'].sel(time='2022-11-09').values)
Out[7]: 
[nan, nan, nan, nan, nan, nan, nan, 3.6112975758332504, nan, nan, nan, 3.6123897126299003,
 3.602228735667318, 3.6071902823546296, 3.5989152582748902, 3.600331164726147,
 3.5951962880115276, 3.599297693561251, 3.595655208111283, 3.596436753864435,
 3.5964484525318636, 3.592583224465607, 3.5951217748425828, 3.599047862357614]
```