### PR TITLE
fixing open-ended adjustements error

### DIFF
--- a/src/pypromice/qc/github_data_issues.py
+++ b/src/pypromice/qc/github_data_issues.py
@@ -180,7 +180,8 @@ def adjustData(ds,
         adj_info.loc[adj_info.t0.isnull(), "t0"] = pd.to_datetime(ds_out.time.values[0], utc=True)
         adj_info.loc[adj_info.t1.isnull(), "t1"] = pd.to_datetime(ds_out.time.values[-1], utc=True)
         # making all timestamps timezone naive (compatibility with xarray)
-        adj_info.t0 = pd.to_datetime(adj_info.t0).dt.tz_localize(None)
+        adj_info.t0 = pd.to_datetime(adj_info.t0, utc=True).dt.tz_localize(None)
+        adj_info.t1 = pd.to_datetime(adj_info.t1, utc=True).dt.tz_localize(None)
         adj_info.t1 = pd.to_datetime(adj_info.t1).dt.tz_localize(None)
 
         # if "*" is in the variable name then we interpret it as regex

--- a/src/pypromice/qc/github_data_issues.py
+++ b/src/pypromice/qc/github_data_issues.py
@@ -176,6 +176,11 @@ def adjustData(ds,
         # removing potential time shifts from the adjustment list
         adj_info = adj_info.loc[adj_info.adjust_function != "time_shift", :]
 
+        # making sure that t0 and t1 columns are object dtype then replaceing nan with None
+        adj_info[['t0','t1']] = adj_info[['t0','t1']].astype(object)
+        adj_info.loc[adj_info.t1.isnull()|(adj_info.t1==''), "t1"] = None      
+        adj_info.loc[adj_info.t0.isnull()|(adj_info.t0==''), "t0"] = None
+		
         # if "*" is in the variable name then we interpret it as regex
         selec =  adj_info['variable'].str.contains('\*') & (adj_info['variable'] != "*")
         for ind in adj_info.loc[selec, :].index:

--- a/src/pypromice/qc/github_data_issues.py
+++ b/src/pypromice/qc/github_data_issues.py
@@ -36,7 +36,7 @@ def flagNAN(ds_in,
     ds : xr.Dataset
         Level 0 data with flagged data
     '''
-    ds = ds_in.copy()
+    ds = ds_in.copy(deep=True)
     df = None
 
     df = _getDF(flag_url + ds.attrs["station_id"] + ".csv",
@@ -99,7 +99,7 @@ def adjustTime(ds,
     ds : xr.Dataset
         Level 0 data with flagged data
     '''
-    ds_out = ds.copy()
+    ds_out = ds.copy(deep=True)
     adj_info=None
 
     adj_info = _getDF(adj_url + ds.attrs["station_id"] + ".csv",
@@ -165,7 +165,7 @@ def adjustData(ds,
     ds : xr.Dataset
         Level 0 data with flagged data
     '''
-    ds_out = ds.copy()
+    ds_out = ds.copy(deep=True)
     adj_info=None
     adj_info = _getDF(adj_url + ds.attrs["station_id"] + ".csv",
                       os.path.join(adj_dir, ds.attrs["station_id"] + ".csv"),

--- a/src/pypromice/qc/github_data_issues.py
+++ b/src/pypromice/qc/github_data_issues.py
@@ -71,7 +71,7 @@ def flagNAN(ds_in,
 
                 for v in varlist:
                     if v in list(ds.keys()):
-                        logger.info(f'---> flagging {t0} {t1} {v}')
+                        logger.info(f'---> flagging {v} between {t0} and {t1}')
                         ds[v] = ds[v].where((ds['time'] < t0) | (ds['time'] > t1))
                     else:
                         logger.info(f'---> could not flag {v} not in dataset')
@@ -227,7 +227,7 @@ def adjustData(ds,
                     logger.info("Time range does not intersect with dataset")
                     continue
 
-                logger.info(f'---> {t0} {t1} {var} {func} {val}')
+                logger.info(f'---> adjusting {var} between {t0} and {t1} ({func} {val})')
 				
                 if func == "add":
                     ds_out[var].loc[index_slice] = ds_out[var].loc[index_slice].values + val

--- a/src/pypromice/qc/github_data_issues.py
+++ b/src/pypromice/qc/github_data_issues.py
@@ -177,8 +177,8 @@ def adjustData(ds,
         adj_info = adj_info.loc[adj_info.adjust_function != "time_shift", :]
 
         # if t1 is left empty, then adjustment is applied until the end of the file
-        adj_info.loc[adj_info.t0.isnull(), "t0"] = ds_out.time.values[0]
-        adj_info.loc[adj_info.t1.isnull(), "t1"] = ds_out.time.values[-1]
+        adj_info.loc[adj_info.t0.isnull(), "t0"] = pd.to_datetime(ds_out.time.values[0], utc=True)
+        adj_info.loc[adj_info.t1.isnull(), "t1"] = pd.to_datetime(ds_out.time.values[-1], utc=True)
         # making all timestamps timezone naive (compatibility with xarray)
         adj_info.t0 = pd.to_datetime(adj_info.t0).dt.tz_localize(None)
         adj_info.t1 = pd.to_datetime(adj_info.t1).dt.tz_localize(None)


### PR DESCRIPTION
While trying to prescribe an open-ended adjustments, I noticed that it currently causes an error.

When we read the start end end times of adjustments, they receive a time zone info due to their ISO format. The AWS xarray dataset does not have a time zone info (because of an [xarray limitation](https://github.com/pydata/xarray/issues/3291)). So the timezone info is removed from the adjustments time bounds (l.183-184).

What was missing is that when start or end date of adjustments are blank (meaning open-start, open-ended bounds), we use a timestamp (then time-zone-naive) from the AWS dataset, and that it then causes an error later on when trying to remove the time-zone info from these same time-zone-naive bounds.