### PR TITLE
Readthedocs sphinx-search version updated

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@ eccodes
 numpy>=1.23.0
 pandas>=1.5.0
 pyDataverse
-readthedocs-sphinx-search==0.1.1
+readthedocs-sphinx-search==0.3.2
 scikit-learn>=1.1.0
 scipy>=1.9.0
 sphinx==5.3.0


### PR DESCRIPTION
This is a simple patch to the readthedocs searching abilities at https://pypromice.readthedocs.io. 

[There has been a security vulnerability](https://github.com/readthedocs/readthedocs-sphinx-search/security/advisories/GHSA-xgfm-fjx6-62mj) found in a previous version on readthedocs-sphinx-search, so the simple solution is to just update the version.

I've tested the readthedocs build with the new version, and it all works fine.