### PR TITLE
QC on GPS data + removing dlr/ulr for bad t_rad + recalculating RH from averaged vapour pressures

### DIFF
--- a/src/pypromice/process/L1toL2.py
+++ b/src/pypromice/process/L1toL2.py
@@ -76,7 +76,7 @@ def toL2(
     # right now baseline elevation is gapfilled monthly median elevation
     baseline_elevation = (ds.gps_alt.to_series().resample('M').median()
                           .interpolate(method='nearest')
-                          .ffill().bfill()
+                          .ffill().bfill())
     mask = (np.abs(ds.gps_alt - baseline_elevation) < 100) & ds.gps_alt.notnull()
     ds[['gps_alt','gps_lon', 'gps_lat']] = ds[['gps_alt','gps_lon', 'gps_lat']].where(mask)
     

--- a/src/pypromice/process/L1toL2.py
+++ b/src/pypromice/process/L1toL2.py
@@ -74,9 +74,9 @@ def toL2(
 
     # filtering gps_lat, gps_lon and gps_alt based on the difference to a baseline elevation
     # right now baseline elevation is gapfilled monthly median elevation
-    baseline_elevation = (ds.gps_alt.resample(time='M').median()
-                          .interp(time=ds.time,method='nearest')
-                          .ffill(dim='time').bfill(dim='time'))
+    baseline_elevation = (ds.gps_alt.to_series().resample('M').median()
+                          .interpolate(method='nearest')
+                          .ffill().bfill()
     mask = (np.abs(ds.gps_alt - baseline_elevation) < 100) & ds.gps_alt.notnull()
     ds[['gps_alt','gps_lon', 'gps_lat']] = ds[['gps_alt','gps_lon', 'gps_lat']].where(mask)
     

--- a/src/pypromice/process/L1toL2.py
+++ b/src/pypromice/process/L1toL2.py
@@ -67,10 +67,10 @@ def toL2(
         logger.exception('Flagging and fixing failed:')
 
     ds = persistence_qc(ds)                                               # Flag and remove persistence outliers
-    if ds.attrs['format'] == 'TX':
-        # TODO: The configuration should be provided explicitly
-        outlier_detector = ThresholdBasedOutlierDetector.default()
-        ds = outlier_detector.filter_data(ds)                                 # Flag and remove percentile outliers
+    # if ds.attrs['format'] == 'TX':
+    #     # TODO: The configuration should be provided explicitly
+    #     outlier_detector = ThresholdBasedOutlierDetector.default()
+    #     ds = outlier_detector.filter_data(ds)                                 # Flag and remove percentile outliers
 
     # filtering gps_lat, gps_lon and gps_alt based on the difference to a baseline elevation
     # right now baseline elevation is gapfilled monthly median elevation

--- a/src/pypromice/process/L1toL2.py
+++ b/src/pypromice/process/L1toL2.py
@@ -75,7 +75,7 @@ def toL2(
     # filtering gps_lat, gps_lon and gps_alt based on the difference to a baseline elevation
     # right now baseline elevation is gapfilled monthly median elevation
     baseline_elevation = (ds.gps_alt.to_series().resample('M').median()
-                          .interpolate(method='nearest')
+                          .reindex(ds.time.to_series().index, method='nearest')
                           .ffill().bfill())
     mask = (np.abs(ds.gps_alt - baseline_elevation) < 100) & ds.gps_alt.notnull()
     ds[['gps_alt','gps_lon', 'gps_lat']] = ds[['gps_alt','gps_lon', 'gps_lat']].where(mask)

--- a/src/pypromice/process/L1toL2.py
+++ b/src/pypromice/process/L1toL2.py
@@ -331,11 +331,8 @@ def correctHumidity(rh, T, T_0, T_100, ews, ei0):                        #TODO f
                    + 0.876793 * (1 - (T + T_0) / T_0)
                    + np.log10(ei0))
 
-    # Define freezing point. Why > -100?
-    freezing = (T < 0) & (T > -100).values
-
     # Set to Groff & Gratch values when freezing, otherwise just rh
-    rh_cor = rh.where(~freezing, other = rh*(e_s_wtr / e_s_ice))
+    rh_cor = xr.where(T>=0, rh, rh*(e_s_wtr / e_s_ice))
     rh_cor = rh_cor.where(T.notnull())
     return rh_cor
 

--- a/src/pypromice/process/L1toL2.py
+++ b/src/pypromice/process/L1toL2.py
@@ -94,12 +94,6 @@ def toL2(
                            ds['dlr'], ds.attrs['station_id'])
     ds['cc'] = (('time'), cc.data)
     
-    # removed by bav: station on bedrock can tilt
-    # anyways cc cannot be either a dataArray and a float
-    # if not ds.attrs['bedrock']:
-    #     # Default cloud cover for bedrock station for which tilt should be 0 anyway.
-    #     cc = 0.8
-
     # Determine surface temperature
     ds['t_surf'] = calcSurfaceTemperature(T_0, ds['ulr'], ds['dlr'],           # Calculate surface temperature
                                           emissivity)

--- a/src/pypromice/process/L1toL2.py
+++ b/src/pypromice/process/L1toL2.py
@@ -272,7 +272,7 @@ def smoothTilt(da: xr.DataArray, threshold=0.2):
     xarray.DataArray
         either X or Y smoothed tilt inclinometer measurements
     '''
-    # we caluclate the moving standard deviation over a 3-day sliding window
+    # we calculate the moving standard deviation over a 3-day sliding window
     # hourly resampling is necessary to make sure the same threshold can be used 
     # for 10 min and hourly data
     moving_std_gap_filled = da.to_series().resample('H').median().rolling(

--- a/src/pypromice/process/L1toL2.py
+++ b/src/pypromice/process/L1toL2.py
@@ -78,8 +78,13 @@ def toL2(
                           .interp(time=ds.time,method='nearest')
                           .ffill(dim='time').bfill(dim='time'))
     mask = (np.abs(ds.gps_alt - baseline_elevation) < 100) & ds.gps_alt.notnull()
-    ds[['gps_alt','gps_lon', 'gps_lat']] = ds4[['gps_alt','gps_lon', 'gps_lat']].where(mask)
-        
+    ds[['gps_alt','gps_lon', 'gps_lat']] = ds[['gps_alt','gps_lon', 'gps_lat']].where(mask)
+    
+    # removing dlr and ulr that are missing t_rad
+    # this is done now becasue t_rad can be filtered either manually or with persistence
+    ds['dlr'] = ds.dlr.where(ds.t_rad.notnull())
+    ds['ulr'] = ds.ulr.where(ds.t_rad.notnull())
+
     T_100 = _getTempK(T_0)
     ds['rh_u_cor'] = correctHumidity(ds['rh_u'], ds['t_u'],
                                      T_0, T_100, ews, ei0)

--- a/src/pypromice/process/L2toL3.py
+++ b/src/pypromice/process/L2toL3.py
@@ -161,7 +161,7 @@ def calcHeatFlux(T_0, T_h, Tsurf_h, rho_atm, WS_h, z_WS, z_T, nu, q_h, p_h,
     es_0 : int 
         Saturation vapour pressure at the melting point (hPa). Default is 6.1071.        
     eps : int 
-        Default is 0.622.
+        Ratio of molar masses of vapor and dry air (0.622).
     gamma : int
         Flux profile correction (Paulson & Dyer). Default is 16..
     L_sub : int  
@@ -313,7 +313,7 @@ def calcHumid(T_0, T_100, T_h, es_0, es_100, eps, p_h, RH_cor_h):
     T_h : xarray.DataArray
         Air temperature
     eps : int 
-        DESCRIPTION
+        ratio of molar masses of vapor and dry air (0.622)
     es_0 : float
         Saturation vapour pressure at the melting point (hPa)
     es_100 : float

--- a/src/pypromice/process/aws.py
+++ b/src/pypromice/process/aws.py
@@ -784,7 +784,9 @@ def calculateSaturationVaporPressure(t, T_0=273.15, T_100=373.15, es_0=6.1071,
     Returns
     -------
     xarray.DataArray
-        Specific humidity data array
+        Saturation vapour pressure with regard to water above 0 C (hPa)
+    xarray.DataArray
+        Saturation vapour pressure where subfreezing timestamps are with regards to ice (hPa)
     '''                                                         
     # Saturation vapour pressure above 0 C (hPa)
     es_wtr = 10**(-7.90298 * (T_100 / (t + T_0) - 1) + 5.02808 * np.log10(T_100 / (t + T_0))

--- a/src/pypromice/process/aws.py
+++ b/src/pypromice/process/aws.py
@@ -723,7 +723,7 @@ def resampleL3(ds_h, t):
     Parameters
     ----------
     ds_h : xarray.Dataset
-        L3 AWS daily dataset
+        L3 AWS dataset either at 10 min (for raw data) or hourly (for tx data)
     t : str
         Resample factor, same variable definition as in
         pandas.DataFrame.resample()
@@ -731,7 +731,7 @@ def resampleL3(ds_h, t):
     Returns
     -------
     ds_d : xarray.Dataset
-        L3 AWS hourly dataset
+        L3 AWS dataset resampled to the frequency defined by t
     '''
     df_d = ds_h.to_dataframe().resample(t).mean()
     

--- a/src/pypromice/process/aws.py
+++ b/src/pypromice/process/aws.py
@@ -798,9 +798,7 @@ def calculateSaturationVaporPressure(t, T_0=273.15, T_100=373.15, es_0=6.1071,
                   + np.log10(es_0)) 
     
     # Saturation vapour pressure (hPa)
-    es_cor = es_wtr
-    freezing = t < 0
-    es_cor[freezing] = es_ice[freezing]
+    es_cor = xr.where(t < 0, es_ice, es_wtr)
     
     return es_wtr, es_cor
 

--- a/src/pypromice/process/aws.py
+++ b/src/pypromice/process/aws.py
@@ -224,7 +224,7 @@ class AWS(object):
 
             except pd.errors.ParserError as e:
                 # ParserError: Too many columns specified: expected 40 and found 38
-                logger.info(f'-----> No msg_lat or msg_lon for {k}')
+                # logger.info(f'-----> No msg_lat or msg_lon for {k}')
                 for item in ['msg_lat', 'msg_lon']:
                     target['columns'].remove(item)                           # Also removes from self.config
                 ds_list.append(self.readL0file(target))

--- a/src/pypromice/process/aws.py
+++ b/src/pypromice/process/aws.py
@@ -752,12 +752,11 @@ def resampleL3(ds_h, t):
             if ('t_'+lvl in ds_h.keys()):
                 es_wtr, es_cor = calculateSaturationVaporPressure(ds_h['t_'+lvl])
                 p_vap = ds_h[var] / 100 * es_wtr
-                p_vap_cor = ds_h[var+'_cor'] / 100 * es_cor
                 
-                df_d[var] = (p_vap.to_dataframe(name='p_vap').p_vap.resample(t).mean() \
-                           / es_wtr.to_dataframe(name='es_wtr').es_wtr.resample(t).mean())*100
-                df_d[var+'_cor'] = (p_vap_cor.to_dataframe(name='p_vap_cor').p_vap_cor.resample(t).mean() \
-                           / es_cor.to_dataframe(name='es_cor').es_cor.resample(t).mean())*100
+                df_d[var] = (p_vap.to_series().resample(t).mean() \
+                           / es_wtr.to_series().resample(t).mean())*100
+                df_d[var+'_cor'] = (p_vap.to_series().resample(t).mean() \
+                           / es_cor.to_series().resample(t).mean())*100
             
     vals = [xr.DataArray(data=df_d[c], dims=['time'],
            coords={'time':df_d.index}, attrs=ds_h[c].attrs) for c in df_d.columns]

--- a/src/pypromice/process/variables.csv
+++ b/src/pypromice/process/variables.csv
@@ -89,4 +89,4 @@ wspd_i,wind_speed,Wind speed (instantaneous),m s-1,0,100,wdir_i wspd_x_i wspd_y_
 wdir_i,wind_from_direction,Wind from direction (instantaneous),degrees,1,360,wspd_x_i wspd_y_i,all,all,4,physicalMeasurement,time lat lon alt,True,For meteorological observations
 wspd_x_i,wind_speed_from_x_direction,Wind speed from x direction (instantaneous),m s-1,-100,100,wdir_i wspd_i,all,all,4,modelResult,time lat lon alt,True,For meteorological observations
 wspd_y_i,wind_speed_from_y_direction,Wind speed from y direction (instantaneous),m s-1,-100,100,wdir_i wspd_i,all,all,4,modelResult,time lat lon alt,True,For meteorological observations
-msg_i,message,Message string (instantaneous),-,,,,all,all,,qualityInformation,time lat lon alt,True,For meteorological observations
+msg_i,message,Message string (instantaneous),-,,,,all,all,,qualityInformation,time lat lon alt,True,L0 only

--- a/src/pypromice/process/variables.csv
+++ b/src/pypromice/process/variables.csv
@@ -89,4 +89,4 @@ wspd_i,wind_speed,Wind speed (instantaneous),m s-1,0,100,wdir_i wspd_x_i wspd_y_
 wdir_i,wind_from_direction,Wind from direction (instantaneous),degrees,1,360,wspd_x_i wspd_y_i,all,all,4,physicalMeasurement,time lat lon alt,True,For meteorological observations
 wspd_x_i,wind_speed_from_x_direction,Wind speed from x direction (instantaneous),m s-1,-100,100,wdir_i wspd_i,all,all,4,modelResult,time lat lon alt,True,For meteorological observations
 wspd_y_i,wind_speed_from_y_direction,Wind speed from y direction (instantaneous),m s-1,-100,100,wdir_i wspd_i,all,all,4,modelResult,time lat lon alt,True,For meteorological observations
-msg_i,message,Message string (instantaneous),-,,,,all,all,,qualityInformation,time lat lon alt,True,L0 only
+msg_i,message,Message string (instantaneous),-,,,,all,,,qualityInformation,time lat lon alt,True,L0 only

--- a/src/pypromice/qc/percentiles/thresholds.csv
+++ b/src/pypromice/qc/percentiles/thresholds.csv
@@ -122,8 +122,8 @@ JAR,p_[ul],881.00,929.00,
 JAR,p_i,-119.00,-71.00,
 JAR,wspd_[uli],-11.62,29.82,
 JAR,t_[uli],-14.60,13.30,summer
-FRE,p_[ul],638.31,799.82,
-FRE,p_i,-361.69,-200.18,
+FRE,p_[ul],800,1000,
+FRE,p_i,-200,0,
 FRE,wspd_[uli],-12.00,22.62,
 FRE,t_[uli],-38.20,10.02,winter
 FRE,t_[uli],-36.55,18.07,spring

--- a/src/pypromice/qc/persistence.py
+++ b/src/pypromice/qc/persistence.py
@@ -17,11 +17,11 @@ logger = logging.getLogger(__name__)
 DEFAULT_VARIABLE_THRESHOLDS = {
     "t": {"max_diff": 0.0001, "period": 2},
     "p": {"max_diff": 0.0001, "period": 2},
-    'gps_lat_lon':{"max_diff": 0.000001, "period": 12},
+    'gps_lat_lon':{"max_diff": 0.000001, "period": 12}, # gets special handling to remove simultaneously constant gps_lat and gps_lon
     'gps_alt':{"max_diff": 0.0001, "period": 12},
     't_rad':{"max_diff": 0.0001, "period": 2},
-    # Relative humidity can be very stable around 100%.
-    #"rh": {"max_diff": 0.0001, "period": 2},
+    "rh": {"max_diff": 0.0001, "period": 2}, # gets special handling to allow constant 100%
+    "wspd": {"max_diff": 0.0001, "period": 6},
 }
 
 
@@ -79,6 +79,8 @@ def persistence_qc(
             if (v in df) | (v == 'gps_lat_lon'):
                 if v != 'gps_lat_lon':
                     mask = find_persistent_regions(df[v], period, max_diff)
+                    if 'rh' in v:
+                        mask = mask & (df[v]<99)
                     n_masked = mask.sum()
                     n_samples = len(mask)
                     logger.info(

--- a/src/pypromice/qc/persistence.py
+++ b/src/pypromice/qc/persistence.py
@@ -19,6 +19,7 @@ DEFAULT_VARIABLE_THRESHOLDS = {
     "p": {"max_diff": 0.0001, "period": 2},
     'gps_lat_lon':{"max_diff": 0.000001, "period": 12},
     'gps_alt':{"max_diff": 0.0001, "period": 12},
+    't_rad':{"max_diff": 0.0001, "period": 2},
     # Relative humidity can be very stable around 100%.
     #"rh": {"max_diff": 0.0001, "period": 2},
 }

--- a/src/pypromice/qc/persistence.py
+++ b/src/pypromice/qc/persistence.py
@@ -133,44 +133,14 @@ def count_consecutive_persistent_values(
 ) -> pd.Series:
     diff = data.ffill().diff().abs()  # forward filling all NaNs!
     mask: pd.Series = diff < max_diff
-    # return count_consecutive_true(mask)
     return duration_consecutive_true(mask)
 
 
-def count_consecutive_true(
-    series: Union[pd.Series, pd.DataFrame]
-) -> Union[pd.Series, pd.DataFrame]:
-    """
-    Convert boolean series to integer series where the values represent the number of connective true values.
-
-    Examples
-    --------
-    >>> count_consecutive_true(pd.Series([False, True, False, False, True, True, True, False, True]))
-    pd.Series([0, 1, 0, 0, 1, 2, 3, 0, 1])
-
-    Parameters
-    ----------
-    series
-        Boolean pandas Series or DataFrame
-
-    Returns
-    -------
-    consecutive_true_count
-        Integer pandas Series or DataFrame with values representing the number of connective true values.
-
-    """
-    # assert series.dtype == bool
-    cumsum = series.cumsum()
-    is_first = series.astype("int").diff() == 1
-    offset = (is_first * cumsum).replace(0, np.nan).fillna(method="ffill").fillna(0)
-    return ((cumsum - offset + 1) * series).astype("int")
-
-
 def duration_consecutive_true(
-    series: Union[pd.Series, pd.DataFrame]
-) -> Union[pd.Series, pd.DataFrame]:
+    series: pd.Series,
+) -> pd.Series:
     """
-    Froma a boolean series, calculates the duration, in hours, of the periods with connective true values.
+    From a boolean series, calculates the duration, in hours, of the periods with connective true values.
 
     Examples
     --------
@@ -179,12 +149,12 @@ def duration_consecutive_true(
 
     Parameters
     ----------
-    series
+    pd.Series
         Boolean pandas Series or DataFrame
 
     Returns
     -------
-    consecutive_true_duration
+    pd.Series
         Integer pandas Series or DataFrame with values representing the number of connective true values.
 
     """

--- a/src/pypromice/qc/persistence.py
+++ b/src/pypromice/qc/persistence.py
@@ -14,13 +14,14 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
+# period is given in hours, 2 persistent 10 min values will be flagged if period < 0.333
 DEFAULT_VARIABLE_THRESHOLDS = {
-    "t": {"max_diff": 0.0001, "period": 2},
-    "p": {"max_diff": 0.0001, "period": 2},
-    'gps_lat_lon':{"max_diff": 0.000001, "period": 12}, # gets special handling to remove simultaneously constant gps_lat and gps_lon
-    'gps_alt':{"max_diff": 0.0001, "period": 12},
-    't_rad':{"max_diff": 0.0001, "period": 2},
-    "rh": {"max_diff": 0.0001, "period": 2}, # gets special handling to allow constant 100%
+    "t": {"max_diff": 0.0001, "period": 0.3},
+    "p": {"max_diff": 0.0001, "period": 0.3},
+    'gps_lat_lon':{"max_diff": 0.000001, "period": 6}, # gets special handling to remove simultaneously constant gps_lat and gps_lon
+    'gps_alt':{"max_diff": 0.0001, "period": 6},
+    't_rad':{"max_diff": 0.0001, "period": 0.3},
+    "rh": {"max_diff": 0.0001, "period": 0.3}, # gets special handling to allow constant 100%
     "wspd": {"max_diff": 0.0001, "period": 6},
 }
 

--- a/src/pypromice/qc/persistence.py
+++ b/src/pypromice/qc/persistence.py
@@ -16,12 +16,12 @@ logger = logging.getLogger(__name__)
 
 # period is given in hours, 2 persistent 10 min values will be flagged if period < 0.333
 DEFAULT_VARIABLE_THRESHOLDS = {
-    "t": {"max_diff": 0.0001, "period": 0.3},
-    "p": {"max_diff": 0.0001, "period": 0.3},
+    "t": {"max_diff": 0.0001, "period": 2},
+    "p": {"max_diff": 0.0001, "period": 2},
     'gps_lat_lon':{"max_diff": 0.000001, "period": 6}, # gets special handling to remove simultaneously constant gps_lat and gps_lon
     'gps_alt':{"max_diff": 0.0001, "period": 6},
-    't_rad':{"max_diff": 0.0001, "period": 0.3},
-    "rh": {"max_diff": 0.0001, "period": 0.3}, # gets special handling to allow constant 100%
+    't_rad':{"max_diff": 0.0001, "period": 2},
+    "rh": {"max_diff": 0.0001, "period": 2}, # gets special handling to allow constant 100%
     "wspd": {"max_diff": 0.0001, "period": 6},
 }
 


### PR DESCRIPTION
# Persistence QC is done on both raw and tx data, and extended to rh and wspd
https://github.com/GEUS-Glaciology-and-Climate/pypromice/blob/304a2706954fb7b2521901807477a3f33e94656e/src/pypromice/process/L1toL2.py#L69-L73
https://github.com/GEUS-Glaciology-and-Climate/pypromice/blob/304a2706954fb7b2521901807477a3f33e94656e/src/pypromice/qc/persistence.py#L23-L24
# QC on GPS data (#238)
Done through
- a persistence QC on gps_lat, gps_lon
- a persistence QC on gps_alt
https://github.com/GEUS-Glaciology-and-Climate/pypromice/blob/304a2706954fb7b2521901807477a3f33e94656e/src/pypromice/qc/persistence.py#L20-L21
If variable 'gps_lat_lon' is given then only times when *both* gps_lat and gps_lon are static are being removed
https://github.com/GEUS-Glaciology-and-Climate/pypromice/blob/304a2706954fb7b2521901807477a3f33e94656e/src/pypromice/qc/persistence.py#L79-L100

- removing all the elevations that deviate from an elevation baseline (gap-filled monthly median) by more than 100 m
- removing gps_lat and gps_lon when gps_alt is missing or has been removed by the steps above
https://github.com/GEUS-Glaciology-and-Climate/pypromice/blob/304a2706954fb7b2521901807477a3f33e94656e/src/pypromice/process/L1toL2.py#L75-L81

See for example here. All the pink points have missing or bad gps_alt. The baseline elevation is the black dashed line.
![QAS_U_0](https://github.com/GEUS-Glaciology-and-Climate/pypromice/assets/35140661/331742e5-bd1d-4ec5-8213-161fff35eaf6)


# Removing dlr and ulr when t_rad is bad or not available (#240)
- static t_rad are identified and removed using persistence QC
https://github.com/GEUS-Glaciology-and-Climate/pypromice/blob/304a2706954fb7b2521901807477a3f33e94656e/src/pypromice/qc/persistence.py#L22
- once QC has been done (either manually or with persistence_qc), dlr and ulr are filtered from non-null t_rad
https://github.com/GEUS-Glaciology-and-Climate/pypromice/blob/304a2706954fb7b2521901807477a3f33e94656e/src/pypromice/process/L1toL2.py#L83-L86

# Re-calculating `rh` from time-average vapour pressures (#193)
RH is defined as the ratio between partial vapour pressure and saturation vapour pressure. When calculating hourly, daily, monthly averages, the ratio of the mean should be taken instead of the mean of the ratio (currently used)

https://github.com/GEUS-Glaciology-and-Climate/pypromice/blob/304a2706954fb7b2521901807477a3f33e94656e/src/pypromice/process/aws.py#L749-L759

https://github.com/GEUS-Glaciology-and-Climate/pypromice/blob/304a2706954fb7b2521901807477a3f33e94656e/src/pypromice/process/aws.py#L767-L805

# removing percentile QC
see #242 

# smoothing and gap-filling tilt (#176, #123)
This is necessary for the calculation of dsr_cor and usr_cor. It is done there:
https://github.com/GEUS-Glaciology-and-Climate/pypromice/blob/304a2706954fb7b2521901807477a3f33e94656e/src/pypromice/process/L1toL2.py#L121-L142
