### PR TITLE
New GC-Net tx message format added

### DIFF
--- a/src/pypromice/tx/payload_formats.csv
+++ b/src/pypromice/tx/payload_formats.csv
@@ -66,6 +66,7 @@ type,expected_values,format,description,flags,notes
 90,47,tfffffffffffffffffffffffffffffffffgneffffffffff,THE GC-NET VERSION!,don’t use,GC-NET stations
 90,48, tfffffffffffffffffffffffffffffffffgnefffffffffff,THE GC-NET VERSION!,don’t use,GC-NET stations
 90,48,tfffffffffffffffffffffffffffffffffgnefffffffffff,THE GC-NET VERSION!,,GC-NET stations
+95,46,tfffffffffffffffffffffffffffffffgnefffffffffff,THE GC-NET VERSION!,,GC-NET stations
 220,29,tfffffffffffffffffffffffnefff,ZAMG Freya 2015 summer message,,ZAMG Freya aws
 221,0,,,,ZAMG Freya aws
 222,29,tfffffffffffffffffffffffnefff,ZAMG Freya 2015 winter message,,ZAMG Freya aws


### PR DESCRIPTION
New GC-Net tx message decoding format added to `src/pypromice/tx/variables.csv`

Message type: 95	
Expected message length: 46	
Message format: tfffffffffffffffffffffffffffffffgnefffffffffff	
Description: THE GC-NET VERSION!
