### PR TITLE
Feature/surface heights and thermistor depths

### DIFF
--- a/src/pypromice/process/L2toL3.py
+++ b/src/pypromice/process/L2toL3.py
@@ -741,7 +741,7 @@ def interpolate_temperature(dates, depth_cor, temp, depth=10, min_diff_to_depth=
     tmp = pd.DataFrame(temp)
     tmp["time"] = dates
     tmp = tmp.set_index("time")
-    tmp = tmp.resample("H").mean()
+    # tmp = tmp.resample("H").mean()
     # tmp = tmp.interpolate(limit=24*7)
     temp = tmp.loc[dates].values
     for i in (range(len(dates))):

--- a/src/pypromice/process/test.py
+++ b/src/pypromice/process/test.py
@@ -40,6 +40,7 @@ class TestProcess(unittest.TestCase):
                      datetime.datetime.now()-timedelta(days=365)]
         d.attrs['station_id']='TEST'
         d.attrs['level']='L2_test'
+        d.attrs['site_type']='ablation'
         meta = getMeta()
         d = addVars(d, v)
         d = addMeta(d, meta)

--- a/src/pypromice/resources/variables.csv
+++ b/src/pypromice/resources/variables.csv
@@ -89,3 +89,20 @@ wspd_i,wind_speed,Wind speed (instantaneous),m s-1,physicalMeasurement,time,TRUE
 wdir_i,wind_from_direction,Wind from direction (instantaneous),degrees,physicalMeasurement,time,TRUE,,1,360,wspd_x_i wspd_y_i,all,1,1,1,4
 wspd_x_i,wind_speed_from_x_direction,Wind speed from x direction (instantaneous),m s-1,modelResult,time,TRUE,L2 or later,-100,100,wdir_i wspd_i,all,0,1,1,4
 wspd_y_i,wind_speed_from_y_direction,Wind speed from y direction (instantaneous),m s-1,modelResult,time,TRUE,L2 or later,-100,100,wdir_i wspd_i,all,0,1,1,4
+z_surf_1,height_of_surface_1,"Surface height 1, relative to surface height at installation and calculated from boom (upper one if two)",m,modelResult,time,FALSE,L3,,,,all,0,0,1,4
+z_surf_2,height_of_surface_2,"Surface height 2, relative to surface height at installation and calculated from stake booms and pt",m,modelResult,time,FALSE,L3,,,,all,0,0,1,4
+z_surf_combined,height_of_surface_combined,"Surface height combined from multiple sensors, relative to ice surface height at installation",m,modelResult,time,FALSE,L3,,,,all,0,0,1,4
+z_ice_surf,height_of_ice_surface,"Ice surface height, relative to ice surface height at installation and calculated from pt_cor and z_stake",m,modelResult,time,FALSE,L3,,,,one-boom,0,0,1,4
+snow_height,height_of_snow,"Snow surface height, relative to ice surface",m,modelResult,time,FALSE,L3,0,,,one-boom,0,0,1,4
+d_t_i_1,depth_of_thermistor_1,Depth of thermistor 1,m,modelResult,time,FALSE,L3,-10,100,,all,0,0,1,4
+d_t_i_2,depth_of_thermistor_2,Depth of thermistor 2,m,modelResult,time,FALSE,L3,-10,100,,all,0,0,1,4
+d_t_i_3,depth_of_thermistor_3,Depth of thermistor 3,m,modelResult,time,FALSE,L3,-10,100,,all,0,0,1,4
+d_t_i_4,depth_of_thermistor_4,Depth of thermistor 4,m,modelResult,time,FALSE,L3,-10,100,,all,0,0,1,4
+d_t_i_5,depth_of_thermistor_5,Depth of thermistor 5,m,modelResult,time,FALSE,L3,-10,100,,all,0,0,1,4
+d_t_i_6,depth_of_thermistor_6,Depth of thermistor 6,m,modelResult,time,FALSE,L3,-10,100,,all,0,0,1,4
+d_t_i_7,depth_of_thermistor_7,Depth of thermistor 7,m,modelResult,time,FALSE,L3,-10,100,,all,0,0,1,4
+d_t_i_8,depth_of_thermistor_8,Depth of thermistor 8,m,modelResult,time,FALSE,L3,-10,100,,all,0,0,1,4
+d_t_i_9,depth_of_thermistor_9,Depth of thermistor 9,m,modelResult,time,FALSE,L3,-10,100,,two-boom,0,0,1,4
+d_t_i_10,depth_of_thermistor_10,Depth of thermistor 10,m,modelResult,time,FALSE,L3,-10,100,,two-boom,0,0,1,4
+d_t_i_11,depth_of_thermistor_11,Depth of thermistor 11,m,modelResult,time,FALSE,L3,-10,100,,two-boom,0,0,1,4
+t_i_10m,10m_subsurface_temperature,10 m subsurface temperature,degrees_C,modelResult,time,FALSE,L3,-70,0,,all,0,0,1,4

--- a/src/pypromice/test/test_config1.toml
+++ b/src/pypromice/test/test_config1.toml
@@ -2,6 +2,7 @@ station_id = 'TEST1'
 logger_type = 'CR1000X'
 nodata     = ['-999', 'NAN'] # if one is a string, all must be strings
 number_of_booms = 1 #1-boom = promice, 2-boom = gc-net
+site_type = 'ablation'
 latitude = 79.91
 longitude = 24.09
 

--- a/src/pypromice/test/test_config2.toml
+++ b/src/pypromice/test/test_config2.toml
@@ -2,6 +2,7 @@ station_id = 'TEST2'
 logger_type = 'CR1000X'
 nodata     = ['-999', 'NAN'] # if one is a string, all must be strings
 number_of_booms = 2
+sitet_type = 'accumulation'
 
 ['test_raw_transmitted2.txt']
 format     = 'TX'


### PR DESCRIPTION
This PR builds on top of #268 as it adds functionality to [L2toL3.py](https://github.com/GEUS-Glaciology-and-Climate/pypromice/blob/feature/surface-heights-and-thermistor-depths/src/pypromice/process/L2toL3.py).

# Surface height processing

The idea of the surface height processing is that there are many cases where automated adjustments can be made. F.e. if the z_pt_cor is working fine, then we can adjust the two SR50 to the end of the ablation period. Or if z_pt_cor is missing but that z_stake is available, then z_stake can be used to describe the ablation of ice instead of the pressure transducer. There are many test being done in [combineSurfaceHeight](https://github.com/GEUS-Glaciology-and-Climate/pypromice/blob/feature/surface-heights-and-thermistor-depths/src/pypromice/process/L2toL3.py#L170) corresponding to recurring situations where the continuity in at least one of the three surface-sensing instruments would allow to adjust the two others.

However, there are still many situations where manual adjustments are needed: e.g. when the station, the stake assembly or the pressure transducer are being maintained, the shift introduced needs to be removed manually. So it is an iterative process between what can be done automatically and what needed to be done manually. A clear tutorial on how to make those adjustment should follow once the PR is implemented.

The result is a `z_surf_combined` ensuring continuity from year to year and combining information from all three surface-sensing instruments. For the ablation stations, the minimum of `z_surf_combined` in the past one year (or in other words the "only-decreasing" version of `z_surf_combined`) represents `z_ice_surf`. The different between  `z_surf_combined` and  `z_ice_surf` (always positive) is the `snow_height`.

The surface height processing does the following:

- It calculates `z_surf_1` from `z_boom_u`, `z_surf_2` from either `z_boom_l` or `z_boom_l`, and `z_ice_surf` from `z_pt_cor`

- After  `z_surf_1`,  `z_surf_2` and  `z_ice_surf_1` are created, they are partially adjusted using the QC [adjustData](https://github.com/GEUS-Glaciology-and-Climate/pypromice/blob/feature/surface-heights-and-thermistor-depths/src/pypromice/qc/github_data_issues.py) function.

- The processing is different is the station is defined as `site_type = 'accumulation'` or `site_type = 'ablation'` in the [updated config files on `aws-l0`](https://geusgitlab.geus.dk/glaciology-and-climate/promice/aws-l0/-/merge_requests/61)

- For the accumulation sites, the `z_surf_combined` and `snow_height` are both defined as the average of  `z_surf_1` and  `z_surf_2` (after the jumps due to maintenance are being removed)

- For the ablation sites, [combineSurfaceHeight](https://github.com/GEUS-Glaciology-and-Climate/pypromice/blob/feature/surface-heights-and-thermistor-depths/src/pypromice/process/L2toL3.py#L515) makes a list of tests and adjustments based on recurrent situations at the station. It first determines for each year the duration of the ablation period (first from z_pt_cor, and if not available, from z_stake, and if not available from the month). Once those periods estimated, then the adjustment loop can begin and is basically a long list of test like "if pressure transducer was working all summer, then adjust the the surface height derived from the two SR50s to the ice surface height on the last ablation day".

- Eventually `z_surf_combined` is taken (to put it simply) as the combination of `z_pt_cor` and `z_stake` in the ablation period and as the combination of `z_boom_u` and `z_stake` in the summer. It should be continuous from year to year and should take its reference "zero" height as the surface height at installation. It only includes surface processes and therefore does not describes completely the elevation change at that site. For this the height change due to ice dynamic should be added to `z_surf_combined`

- For each timestamp, the minimum of `z_surf_combined` in the past one year (or in other words the "only-decreasing" version of `z_surf_combined`) represents `z_ice_surf`. The different between  `z_surf_combined` and  `z_ice_surf` (always positive) is the `snow_height`.

# Thermistor depth calculation

Besides a continuous surface height, the thermistor depth calculation needs a list of thermistor re-installation and, if available, the non-standard depths at which they were installed. This info was digitized from maintenance sheet and posted on [AWS-L0/metadata](https://geusgitlab.geus.dk/glaciology-and-climate/promice/aws-l0/-/blob/main/metadata/fieldwork_summary_PROMICE_GC-Net.csv?ref_type=heads) (we can discuss where we can have this file so that it is easy to update and easy to pull by our processing scripts.

The depth for each thermistor `d_t_*` s calculated from surface height change (burial when surface height increases and inversely) and depth are reset each time there is a maintenance. These depth then indicate whenever thermistors are likely melting out due to ablation, and therefore can be used to further clean the `t_i_*` variables.

After those depths are calculates, and interpolation function allows to calculate, for each timestamp the 10 m subsurface temperature `t_i_10m` (if there are thermistors close enough to that depth). Note that, in the accumulation area, we assume that the snow and firn compaction does not affect the spacing between the thermistor.



