### PR TITLE
Bugfix/correct persistent qc

### DIFF
--- a/.github/workflows/process_test.yml
+++ b/.github/workflows/process_test.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.8"        
+          python-version: "3.10"
       - name: Checkout repo
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: ['3.8','3.9','3.10']
+        python_version: ['3.10', '3.11']
     steps:
       - name: Install Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
* Updated persistence.py to use explicit variable thresholds. Avoided applying the persistence filter on averaged pressure variables (`p_u` and `p_l`) due to their 0 decimal precision often leading to incorrect filtering.
* Fixed bug in persistence QC where initial repetitions were ignored
* Relocated unit persistence tests
* Added explicit test for `get_duration_consecutive_true`
* Renamed `duration_consecutive_true` to `get_duration_consecutive_true` for imperative clarity