### PR TITLE
Gap filling with NaN values added to Level 2

### DIFF
--- a/src/pypromice/process/L1toL2.py
+++ b/src/pypromice/process/L1toL2.py
@@ -217,6 +217,7 @@ def toL2(
     
 
     ds = clip_values(ds, vars_df)
+    ds = fill_gaps(ds)
     return ds
 
 
@@ -770,6 +771,35 @@ def calcCorrectionFactor(Declination_rad, phi_sensor_rad, theta_sensor_rad,
 
     return CorFac_all
 
+def fill_gaps(ds):
+    '''Fill data gaps with nan values
+    
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        Data set to gap fill
+    
+    Returns
+    -------
+    ds_filled : xarray.Dataset
+        Gap-filled dataset
+    '''    
+    # Determine time range of dataset
+    min_date = ds.to_dataframe().index.min()
+    max_date = ds.to_dataframe().index.max()
+    
+    # Determine common time interval
+    time_diffs = np.diff(ds['time'].values)
+    common_diff = pd.Timedelta(pd.Series(time_diffs).mode()[0])
+    
+    # Determine gap filled index
+    full_time_range = pd.date_range(start=min_date, 
+                                    end=max_date, 
+                                    freq=common_diff)
+    
+    # Apply gap-fille index to dataset
+    ds_filled = ds.reindex({'time': full_time_range}, fill_value=np.nan)
+    return ds_filled
 
 def _checkSunPos(ds, OKalbedos, sundown, sunonlowerdome, TOA_crit_nopass):
     '''Check sun position


### PR DESCRIPTION
I have added a gap filling step so that Level 2 data should not have any gaps. Instead, gaps should now be filled with NaN values. The following steps occur:

- Determine the datetime range of the dataset
- Determine the most common time interval (i.e. 10 minute, hourly etc.)
- Generate an index with no gaps
- Reindex the dataset to the new index 

I found that this was occurring at times when stations were being visited, and therefore there are gaps in the data when maintenance is being carried out and the station is offline. In most cases, this is only for a couple of hours. But then NaN gaps were not present in the Level 2 dataset - the dataset just jumped from the hour the station went offline, to when it is online again.

I am open to suggestions for where this functionality should go. For now, it is in the `L1toL2` processing as a step at the end before the Level 2 dataset is returned. However, another option could be for this to go in the `write` function. 