### PR TITLE
Feature/gps data decoding 60min tables

### DIFF
--- a/src/pypromice/process/L0toL1.py
+++ b/src/pypromice/process/L0toL1.py
@@ -65,9 +65,15 @@ def toL1(L0, vars_df, T_0=273.15, tilt_threshold=-100):
     if ds['gps_lat'].dtype.kind == 'O':                                        # Decode and reformat GPS information
         if 'NH' in ds['gps_lat'].dropna(dim='time').values[1]:
             ds = decodeGPS(ds, ['gps_lat','gps_lon','gps_time'])
+        elif 'L' in ds['gps_lat'].dropna(dim='time').values[1]:
+            logger.info('Found L in GPS string')
+            ds = decodeGPS(ds, ['gps_lat','gps_lon','gps_time'])
+            for l in ['gps_lat', 'gps_lon']:
+                ds[l] = ds[l]/100000
         else:
             try:
                 ds = decodeGPS(ds, ['gps_lat','gps_lon','gps_time'])          # TODO this is a work around specifically for L0 RAW processing for THU_U. Find a way to make this slicker
+            
             except:
                 print('Invalid GPS type {ds["gps_lat"].dtype} for decoding')
             
@@ -180,7 +186,7 @@ def addTimeShift(ds, vars_df):
         if ds.attrs['logger_type'] == 'CR1000X':
             # v3, data is hourly all year long
             # shift everything except instantaneous
-            df_a = df_a.shift(periods=-1, freq="H")
+            df_a = df_a.shift(periods=-1, freq="h")
             df_out = pd.concat([df_a, df_i], axis=1) # different columns, same datetime indices
             df_out = df_out.sort_index()
         elif ds.attrs['logger_type'] == 'CR1000':


### PR DESCRIPTION
fixes #286 :

The logger file 'CEN_2024_DataTanle60min.dat' has the following format for GPS data:

```
"Gtime","Glat","Glon","Altitude"
"L16001000","L771091802","L0610693836",1898
```

which is currently not properly handled by pypromice.

Both the transmission file and the 10min data files have the proper format:
```
"TimeGPS","Latitude","Longitude","Altitude"
"210004.00","7710.91812","06106.94157",1891
```

The suggested modif should read the data properly.