### PR TITLE
Bugfix/passing adj dir to l3 processing plus attribute fix

### DIFF
--- a/.github/workflows/process_test.yml
+++ b/.github/workflows/process_test.yml
@@ -40,7 +40,7 @@ jobs:
           mkdir $GITHUB_WORKSPACE/out/L0toL2/
           mkdir $GITHUB_WORKSPACE/data_issues
           for i in $(echo ${{ env.TEST_STATION }} | tr ' ' '\n'); do
-            python3 $GITHUB_WORKSPACE/main/src/pypromice/process/get_l2.py -c $GITHUB_WORKSPACE/aws-l0/tx/config/$i.toml -i $GITHUB_WORKSPACE/aws-l0/tx --issues $GITHUB_WORKSPACE/data_issues -o $GITHUB_WORKSPACE/out/L0toL2/
+            python3 $GITHUB_WORKSPACE/main/src/pypromice/process/get_l2.py -c $GITHUB_WORKSPACE/aws-l0/tx/config/$i.toml -i $GITHUB_WORKSPACE/aws-l0/tx --issues $GITHUB_WORKSPACE/data_issues -o $GITHUB_WORKSPACE/out/L0toL2/ --data_issues_path $GITHUB_WORKSPACE/data_issues
           done
       - name: Run L2 to L3 processing
         env:
@@ -50,7 +50,7 @@ jobs:
           mkdir $GITHUB_WORKSPACE/out/L2toL3/
           for i in $(echo ${{ env.TEST_STATION }} | tr ' ' '\n'); do
             echo ${i}_hour.nc
-            python3 $GITHUB_WORKSPACE/main/src/pypromice/process/get_l2tol3.py -c $GITHUB_WORKSPACE/aws-l0/metadata/station_configurations/ -i $GITHUB_WORKSPACE/out/L0toL2/${i}/${i}_hour.nc -o $GITHUB_WORKSPACE/out/L2toL3/
+            python3 $GITHUB_WORKSPACE/main/src/pypromice/process/get_l2tol3.py -c $GITHUB_WORKSPACE/aws-l0/metadata/station_configurations/ -i $GITHUB_WORKSPACE/out/L0toL2/${i}/${i}_hour.nc -o $GITHUB_WORKSPACE/out/L2toL3/ --data_issues_path $GITHUB_WORKSPACE/data_issues
           done
       - name: Upload test output
         uses: actions/upload-artifact@v3

--- a/src/pypromice/process/aws.py
+++ b/src/pypromice/process/aws.py
@@ -153,7 +153,7 @@ class AWS(object):
         """Perform L2 to L3 data processing, including resampling and metadata
         and attribute population"""
         logger.info("Level 3 processing...")
-        self.L3 = toL3(self.L2)
+        self.L3 = toL3(self.L2, data_adjustments_dir=self.data_issues_repository / "adjustments")
 
     def writeArr(self, dataset, outpath, t=None):
         """Write L3 data to .nc and .csv hourly and daily files

--- a/src/pypromice/process/get_l2.py
+++ b/src/pypromice/process/get_l2.py
@@ -31,10 +31,27 @@ def get_l2(config_file, inpath, outpath, variables, metadata, data_issues_path: 
     # Define input path
     station_name = config_file.split('/')[-1].split('.')[0] 
     station_path = os.path.join(inpath, station_name)
+    
+    # checking that data_issues_path is valid
+    if data_issues_path is None:
+        data_issues_path = Path("../PROMICE-AWS-data-issues")
+        if data_issues_path.exists():
+            logging.warning(f"data_issues_path is missing. Using default data issues path: {data_issues_path}")
+        else:
+            raise ValueError("data_issues_path is missing. Please provide a valid path to the data issues repository")
+
     if os.path.exists(station_path):
-        aws = AWS(config_file, station_path, data_issues_repository=data_issues_path, var_file=variables, meta_file=metadata)
+        aws = AWS(config_file, 
+                  station_path,
+                  data_issues_repository=data_issues_path, 
+                  var_file=variables, 
+                  meta_file=metadata)
     else:
-        aws = AWS(config_file, inpath, data_issues_repository=data_issues_path, var_file=variables, meta_file=metadata)
+        aws = AWS(config_file, 
+                  inpath, 
+                  data_issues_repository=data_issues_path, 
+                  var_file=variables, 
+                  meta_file=metadata)
 
     # Perform level 1 and 2 processing
     aws.getL1()
@@ -58,21 +75,13 @@ def main():
         stream=sys.stdout,
     )
 
-    data_issues_path = args.data_issues_path
-    if data_issues_path is None:
-        data_issues_path = Path("../PROMICE-AWS-data-issues")
-        if data_issues_path.exists():
-            logging.warning(f"data_issues_path is missing. Using default data issues path: {data_issues_path}")
-        else:
-            raise ValueError(f"data_issues_path is missing. Please provide a valid path to the data issues repository")
-
     _ = get_l2(
         args.config_file,
         args.inpath,
         args.outpath,
         args.variables,
         args.metadata,
-        data_issues_path=data_issues_path,
+        args.data_issues_path,
     )
 
 

--- a/src/pypromice/process/get_l2tol3.py
+++ b/src/pypromice/process/get_l2tol3.py
@@ -31,7 +31,7 @@ def parse_arguments_l2tol3(debug_args=None):
     args = parser.parse_args(args=debug_args)
     return args
 
-def get_l2tol3(config_folder: Path|str, inpath, outpath, variables, metadata, data_issues_path: Path):
+def get_l2tol3(config_folder: Path|str, inpath, outpath, variables, metadata, data_issues_path: Path|str):
     if isinstance(config_folder, str):
         config_folder = Path(config_folder)
 
@@ -78,6 +78,9 @@ def get_l2tol3(config_folder: Path|str, inpath, outpath, variables, metadata, da
             logging.warning(f"data_issues_path is missing. Using default data issues path: {data_issues_path}")
         else:
             raise ValueError("data_issues_path is missing. Please provide a valid path to the data issues repository")
+    else:
+        data_issues_path = Path(data_issues_path)
+
     data_adjustments_dir = data_issues_path / "adjustments"
     
     # Perform Level 3 processing

--- a/src/pypromice/process/join_l3.py
+++ b/src/pypromice/process/join_l3.py
@@ -493,7 +493,9 @@ def join_l3(config_folder, site, folder_l3, folder_gcnet, outpath, variables, me
                             l3_merged.z_ice_surf.to_series(), l3.z_ice_surf.to_series()
                         ),
                     )
-
+            
+            # saves attributes
+            attrs = l3_merged.attrs
             # merging by time block
             l3_merged = xr.concat(
                 (
@@ -504,6 +506,9 @@ def join_l3(config_folder, site, folder_l3, folder_gcnet, outpath, variables, me
                 ),
                 dim="time",
             )
+            
+            # restauring attributes
+            l3_merged.attrs = attrs
 
     # Assign site id
     if not l3_merged:
@@ -519,13 +524,15 @@ def join_l3(config_folder, site, folder_l3, folder_gcnet, outpath, variables, me
         site_config_source_hash=get_commit_hash_and_check_dirty(config_folder),
         gcnet_source_hash=get_commit_hash_and_check_dirty(folder_gcnet),
     )
+
     for stid, station_attributes in l3_merged.attrs["stations_attributes"].items():
-        station_source = json.loads(station_attributes["source"])
-        for k, v in station_source.items():
-            if k in site_source and site_source[k] != v:
-                site_source[k] = "multiple"
-            else:
-                site_source[k] = v
+        if "source" in station_attributes.keys():
+            station_source = json.loads(station_attributes["source"])
+            for k, v in station_source.items():
+                if k in site_source and site_source[k] != v:
+                    site_source[k] = "multiple"
+                else:
+                    site_source[k] = v
     l3_merged.attrs["source"] = json.dumps(site_source)
 
     v = pypromice.resources.load_variables(variables)

--- a/src/pypromice/qc/github_data_issues.py
+++ b/src/pypromice/qc/github_data_issues.py
@@ -308,7 +308,7 @@ def _getDF(flag_file):
                         ).dropna(how='all', axis='rows')
     else:
         df=None
-        logger.info(f"No {flag_file.split('/')[-2][:-1]} file to read.")
+        logger.info(f"No {flag_file} file to read.")
     return df
 
 

--- a/tests/e2e/test_process.py
+++ b/tests/e2e/test_process.py
@@ -153,6 +153,7 @@ class TestProcess(unittest.TestCase):
                 outpath=output_l3.as_posix(),
                 variables=None,
                 metadata=None,
+                data_issues_path=data_issues_path,
             )
 
             # Part 4 Join L3: Merge Current data and historical GC-Net and convert to site


### PR DESCRIPTION
[passing adjustment_dir to L2toL3.py](https://github.com/GEUS-Glaciology-and-Climate/pypromice/commit/c4e45205e3e54b2d2aa287cb00ae5bae8a98231d) (and get_l2tol3)

I also moved the handling of `data_issues_path is None` from the `main` function to either `get_l2tol3` and `get_l2` so that the functions can also be imported and used with `data_issues_path=None`

[fixing attributes in join_l3](https://github.com/GEUS-Glaciology-and-Climate/pypromice/commit/167846591c5e9ba2aeb507370d1dbaee5e0b444e):
- `station_attribute` containing info from merged dataset was lost when concatenating the datasets
- The key "source" is not present in the attributes of the old GC-Net files so `station_source = json.loads(station_attributes["source"])` was throwing an error