### PR TITLE
Minimum Python version updated

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setuptools.setup(
     package_dir={"": "src"},
     include_package_data = True,
     packages=setuptools.find_packages(where="src"),
-    python_requires=">=3.8",
+    python_requires=">=3.10",
     package_data={
     	"pypromice.tx": ["payload_formats.csv", "payload_types.csv"],
         "pypromice.qc.percentiles": ["thresholds.csv"],


### PR DESCRIPTION
Minimum Python version updated from 3.8 to 3.10. This is because >3.10 is faster and better suited for our installation tests. 