### PR TITLE
Updated the `attrs['source']` hash strings:

### DIFF
--- a/src/pypromice/postprocess/bufr_to_csv.py
+++ b/src/pypromice/postprocess/bufr_to_csv.py
@@ -1,15 +1,22 @@
 import argparse
 from pathlib import Path
 
+import pandas as pd
+
 from pypromice.postprocess.bufr_utilities import read_bufr_file
 
 
 def main():
     parser = argparse.ArgumentParser("BUFR to CSV converter")
-    parser.add_argument("path", type=Path)
+    parser.add_argument("path", type=Path, nargs='+')
     args = parser.parse_args()
 
-    print(read_bufr_file(args.path).to_csv())
+    paths = []
+    for path in args.path:
+        paths += list(path.parent.glob(path.name))
+
+    df = pd.concat([read_bufr_file(path) for path in paths])
+    print(df.to_csv())
 
 
 if __name__ == "__main__":

--- a/src/pypromice/process/aws.py
+++ b/src/pypromice/process/aws.py
@@ -55,7 +55,15 @@ class AWS(object):
         """
         assert os.path.isfile(config_file), "cannot find " + config_file
         assert os.path.isdir(inpath), "cannot find " + inpath
-        logger.info("AWS object initialising...")
+        logger.info(
+            "AWS("
+            f"config_file={config_file},"
+            f" inpath={inpath},"
+            f" data_issues_repository={data_issues_repository},"
+            f" var_file={var_file},"
+            f" meta_file={meta_file}"
+            ")"
+        )
 
         # Load config, variables CSF standards, and L0 files
         self.config = self.loadConfig(config_file, inpath)
@@ -73,6 +81,7 @@ class AWS(object):
             l0_data_root=inpath_hash,
             data_issues=data_issues_hash,
         )
+        logger.debug('Source information: %s', source_dict)
         self.meta["source"] = json.dumps(source_dict)
 
         # Load config file

--- a/src/pypromice/utilities/git.py
+++ b/src/pypromice/utilities/git.py
@@ -56,7 +56,6 @@ def get_commit_hash_and_check_dirty(file_path: str | Path) -> str:
             logger.warning(f"Warning: The file {file_path} is not under version control.")
             return 'unknown'
 
-        print(f"Commit hash: {commit_hash}")
         return commit_hash
     except subprocess.CalledProcessError as e:
         logger.warning(f"Error: {e.output.decode('utf-8')}")

--- a/src/pypromice/utilities/git.py
+++ b/src/pypromice/utilities/git.py
@@ -7,12 +7,16 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def get_commit_hash_and_check_dirty(file_path) -> str:
-    repo_path = Path(file_path).parent
+def get_commit_hash_and_check_dirty(file_path: str | Path) -> str:
+    if isinstance(file_path, str):
+        file_path = Path(file_path)
+    if file_path.is_dir():
+        repo_path = file_path
+    else:
+        repo_path = file_path.parent
 
     try:
         # Ensure the file path is relative to the repository
-        relative_file_path = os.path.relpath(file_path, repo_path)
 
         # Get the latest commit hash for the file
         commit_hash = (
@@ -25,8 +29,6 @@ def get_commit_hash_and_check_dirty(file_path) -> str:
                     "-n",
                     "1",
                     "--pretty=format:%H",
-                    #"--",
-                    #relative_file_path,
                 ],
                 stderr=subprocess.STDOUT,
             )
@@ -49,7 +51,7 @@ def get_commit_hash_and_check_dirty(file_path) -> str:
 
         if is_dirty:
             logger.warning(f"Warning: The file {file_path} is dirty compared to the last commit. {commit_hash}")
-            return 'unknown'
+            return f'{commit_hash} (dirty)'
         if commit_hash == "":
             logger.warning(f"Warning: The file {file_path} is not under version control.")
             return 'unknown'

--- a/tests/e2e/test_get_l2.py
+++ b/tests/e2e/test_get_l2.py
@@ -129,6 +129,6 @@ class GetL2TestCase(unittest.TestCase):
                 )
                 data_root_hash = source_decoded["l0_data_root"]
                 data_issues_hash = source_decoded["data_issues"]
-                self.assertNotEquals(config_hash, 'unknown', 'This test will fail while the commit is dirty')
-                self.assertNotEquals(data_root_hash, 'unknown', 'This test will fail while the commit is dirty')
-                self.assertNotEquals(data_issues_hash, 'unknown', 'This test will fail while the commit is dirty')
+                self.assertFalse(config_hash.endswith(" (dirty)"), 'This test will fail while the commit is dirty')
+                self.assertFalse(data_root_hash.endswith(" (dirty)"), 'This test will fail while the commit is dirty')
+                self.assertFalse(data_issues_hash.endswith(" (dirty)"), 'This test will fail while the commit is dirty')


### PR DESCRIPTION
* Now includes the git commit ID in the source string when the repository has uncommitted changes for reference.
* Removed assumptions about relative paths and repository roots in the input file paths. The previous approach assumed the data issues path was already the root, causing the function to fail.