### PR TITLE
Fixed format test

### DIFF
--- a/src/pypromice/process/aws.py
+++ b/src/pypromice/process/aws.py
@@ -94,7 +94,7 @@ class AWS(object):
         formats = {dataset.attrs["format"].lower() for dataset in self.L0}
         if "raw" in formats:
             self.format = "raw"
-        elif "STM" in formats:
+        elif "stm" in formats:
             self.format = "STM"
         elif "tx" in formats:
             self.format = "tx"


### PR DESCRIPTION
Bug origin: first we make all the format `.lower()` and then we test whether it matches with "STM"
Fixed now.

It is making the test of new logger files fail on AWS-L0: https://geusgitlab.geus.dk/glaciology-and-climate/promice/aws-l0/-/pipelines/7178/failures