### PR TITLE
ISWR and OSWR in GC-Net historical data should be used for dsr and usr instead of dsr_cor and usr_cor

### DIFF
--- a/src/pypromice/resources/variable_aliases_GC-Net.csv
+++ b/src/pypromice/resources/variable_aliases_GC-Net.csv
@@ -14,10 +14,10 @@ wspd_u,VW2
 wspd_l,VW1
 wdir_u,DW2
 wdir_l,DW1
-dsr,
-dsr_cor,ISWR
-usr,
-usr_cor,OSWR
+dsr,ISWR
+dsr_cor,
+usr,OSWR
+usr_cor,
 albedo,Alb
 dlr,
 ulr,


### PR DESCRIPTION
fix #319