### PR TITLE
Gap filling with NaN values added to Level 2

### DIFF
--- a/src/pypromice/process/L1toL2.py
+++ b/src/pypromice/process/L1toL2.py
@@ -205,9 +205,10 @@ def toL2(
             ds['precip_l_cor'], ds['precip_l_rate']= correctPrecip(ds['precip_l'],
                                                                    ds['wspd_l'])
 
-    get_directional_wind_speed(ds)                                            # Get directional wind speed
+    get_directional_wind_speed(ds)  # Get directional wind speed
 
     ds = clip_values(ds, vars_df)
+    ds = fill_gaps(ds)
     return ds
 
 def get_directional_wind_speed(ds: xr.Dataset) -> xr.Dataset:
@@ -782,6 +783,35 @@ def calcCorrectionFactor(Declination_rad, phi_sensor_rad, theta_sensor_rad,
 
     return CorFac_all
 
+def fill_gaps(ds):
+    '''Fill data gaps with nan values
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        Data set to gap fill
+
+    Returns
+    -------
+    ds_filled : xarray.Dataset
+        Gap-filled dataset
+    '''
+    # Determine time range of dataset
+    min_date = ds.to_dataframe().index.min()
+    max_date = ds.to_dataframe().index.max()
+
+    # Determine common time interval
+    time_diffs = np.diff(ds['time'].values)
+    common_diff = pd.Timedelta(pd.Series(time_diffs).mode()[0])
+
+    # Determine gap filled index
+    full_time_range = pd.date_range(start=min_date,
+                                    end=max_date,
+                                    freq=common_diff)
+
+    # Apply gap-fille index to dataset
+    ds_filled = ds.reindex({'time': full_time_range}, fill_value=np.nan)
+    return ds_filled
 
 def _checkSunPos(ds, OKalbedos, sundown, sunonlowerdome, TOA_crit_nopass):
     '''Check sun position


### PR DESCRIPTION
**Context:**

This pull request supersedes [PR #283](https://github.com/GEUS-Glaciology-and-Climate/pypromice/pull/283), which was automatically closed due to the deletion of the `develop` branch. The `bugfix/level_2_data_gaps` branch has been rebased onto `main`, and this new PR is being submitted to continue the integration process.

**Summary of Original PR (#283):**

- **Title:** Gap filling with NaN values added to Level 2
- **Description:** Introduced a gap-filling step ensuring that Level 2 data no longer contains gaps. Specifically:
  - Determined the datetime range of the dataset.
  - Identified the most common time interval (e.g., 10 minutes, hourly).
  - Generated an index without gaps.
  - Reindexed the dataset accordingly.

For a detailed view of the original changes and discussions, please refer to [PR #283](https://github.com/GEUS-Glaciology-and-Climate/pypromice/pull/283).
