### PR TITLE
[DRAFT] L0toL1 functionality restructured

### DIFF
--- a/src/pypromice/process/L0toL1.py
+++ b/src/pypromice/process/L0toL1.py
@@ -7,6 +7,7 @@ import pandas as pd
 import xarray as xr
 import re, logging
 from pypromice.process.value_clipping import clip_values
+from pypromice.process import radiation, pressure_depth, boom_height, tilt
 logger = logging.getLogger(__name__)
 
 
@@ -28,14 +29,20 @@ def toL1(L0, vars_df, T_0=273.15, tilt_threshold=-100):
     -------
     ds : xarray.Dataset
         Level 1 dataset
-    '''    
+    '''
+    # Assert input type
     assert(type(L0) == xr.Dataset)
+
+    # Reassign input
     ds = L0
+
+    # Add Level 1 attribute
     ds.attrs['level'] = 'L1'
 
+    # Reformat most variables
     for l in list(ds.keys()):
         if l not in ['time', 'msg_i', 'gps_lat', 'gps_lon', 'gps_alt', 'gps_time']:
-            ds[l] = _reformatArray(ds[l])
+            ds[l] = _reformatArray(ds[l])                                               # TODO reformatting to occur as it is loaded as L0? PHO.
 
     # ds['time_orig'] = ds['time'] # Not used
 
@@ -46,84 +53,148 @@ def toL1(L0, vars_df, T_0=273.15, tilt_threshold=-100):
     ds = ds.isel(time=index)
 
     # If we do not want to shift hourly average values back -1 hr, then comment the following line.
-    ds = addTimeShift(ds, vars_df)
+    ds = add_time_shift(ds, vars_df)
 
-    if hasattr(ds, 'dsr_eng_coef'): 
-        ds['dsr'] = (ds['dsr'] * 10) / ds.attrs['dsr_eng_coef']                # Convert radiation from engineering to physical units
-    if hasattr(ds, 'usr_eng_coef'):                                            # TODO add metadata to indicate whether radiometer values are corrected with calibration values or not
-        ds['usr'] = (ds['usr'] * 10) / ds.attrs['usr_eng_coef']
+    # Correct radiation measurements with coefficients
+    if hasattr(ds, 'dsr_eng_coef'):
+        ds['dsr'] = radiation.convert_sr(ds['dsr'],
+                                         ds.attrs['dsr_eng_coef'])
+    if hasattr(ds, 'usr_eng_coef'):
+        ds['usr'] = radiation.convert_sr(ds['usr'],
+                                         ds.attrs['usr_eng_coef'])
     if hasattr(ds, 'dlr_eng_coef'):
-        ds['dlr'] = ((ds['dlr'] * 10) / ds.attrs['dlr_eng_coef']) + 5.67E-8*(ds['t_rad'] + T_0)**4
+        ds['dlr'] = radiation.convert_lr(ds['dlr'],
+                                         ds['t_rad'],
+                                         ds.attrs['dlr_eng_coef'])
     if hasattr(ds, 'ulr_eng_coef'):
-        ds['ulr'] = ((ds['ulr'] * 10) / ds.attrs['ulr_eng_coef']) + 5.67E-8*(ds['t_rad'] + T_0)**4
+        ds['ulr'] = radiation.convert_lr(ds['ulr'],
+                                         ds['t_rad'],
+                                         ds.attrs['ulr_eng_coef'])
 
-    ds['z_boom_u'] = _reformatArray(ds['z_boom_u'])                            # Reformat boom height
-    
-    ds['t_u_interp'] = interpTemp(ds['t_u'], vars_df)
-    ds['z_boom_u'] = ds['z_boom_u'] * ((ds['t_u_interp'] + T_0)/T_0)**0.5      # Adjust sonic ranger readings for sensitivity to air temperature       
-    
+    # Reformat boom height
+    ds['z_boom_u'] = _reformat_array(ds['z_boom_u'])                            # TODO Is this needed as it should be done on line 45? PHO
+
+    # Correct boom height for air temperature sensitivity
+    ds['z_boom_u'] = boom_height.correct_with_temp_interp(ds['z_boom_u'],
+                                                          ds['t_u'],
+                                                          vars_df,
+                                                          T_0)
+
+    # Decode GPS information
     if ds['gps_lat'].dtype.kind == 'O':                                        # Decode and reformat GPS information
         if 'NH' in ds['gps_lat'].dropna(dim='time').values[1]:
-            ds = decodeGPS(ds, ['gps_lat','gps_lon','gps_time'])
+            logger.info('Found NH in GPS string')
+            ds['gps_lat'] = gps.decode(ds['gps_lat'])
+            ds['gps_lon'] = gps.decode(ds['gps_lon'])
+            ds['gps_alt'] = gps.decode(ds['gps_alt'])
+
         elif 'L' in ds['gps_lat'].dropna(dim='time').values[1]:
             logger.info('Found L in GPS string')
-            ds = decodeGPS(ds, ['gps_lat','gps_lon','gps_time'])
+            ds['gps_lat'] = gps.decode(ds['gps_lat'])
+            ds['gps_lon'] = gps.decode(ds['gps_lon'])
+            ds['gps_alt'] = gps.decode(ds['gps_alt'])
             for l in ['gps_lat', 'gps_lon']:
                 ds[l] = ds[l]/100000
         else:
             try:
-                ds = decodeGPS(ds, ['gps_lat','gps_lon','gps_time'])          # TODO this is a work around specifically for L0 RAW processing for THU_U. Find a way to make this slicker
-            
+                # TODO this is a work around specifically for L0 RAW processing for THU_U.
+                #  There should be a way to make this slicker. PHO
+                ds['gps_lat'] = gps.decode(ds['gps_lat'])
+                ds['gps_lon'] = gps.decode(ds['gps_lon'])
+                ds['gps_alt'] = gps.decode(ds['gps_alt'])
+                logger.info('No GPS string type detected, but decoding was successfully completed')
             except:
-                print('Invalid GPS type {ds["gps_lat"].dtype} for decoding')
-            
+                logger.info('Invalid GPS type {ds["gps_lat"].dtype} for decoding')
+
+    # Reformat gps measurements
     for l in ['gps_lat', 'gps_lon', 'gps_alt','gps_time']:
-        ds[l] = _reformatArray(ds[l])  
+        ds[l] = _reformat_array(ds[l])
 
+    # Reformat gps measurements if originating latitude and longitude positions are provided
     if hasattr(ds, 'latitude') and hasattr(ds, 'longitude'):
-        ds['gps_lat'] = reformatGPS(ds['gps_lat'], ds.attrs['latitude'])
-        ds['gps_lon'] = reformatGPS(ds['gps_lon'], ds.attrs['longitude'])
+        logger.info('GPS reformatted based on latitude {ds.attrs["latitude"]}, longitude {ds.attrs["longitude"]}')
+        ds['gps_lat'] = gps.reformat(ds['gps_lat'],
+                                     ds.attrs['latitude'])
+        ds['gps_lon'] = gps.reformat(ds['gps_lon'],
+                                     ds.attrs['longitude'])
 
-    if hasattr(ds, 'logger_type'):                                             # Convert tilt voltage to degrees
-        if ds.attrs['logger_type'].upper() == 'CR1000':                    
-            ds['tilt_x']  = getTiltDegrees(ds['tilt_x'], tilt_threshold) 
-            ds['tilt_y'] = getTiltDegrees(ds['tilt_y'], tilt_threshold)  
-            
-    if hasattr(ds, 'tilt_y_factor'):                                           # Apply tilt factor (e.g. -1 will invert tilt angle)
-        ds['tilt_y'] = ds['tilt_y']*ds.attrs['tilt_y_factor']
+    # Convert and filter tilt to degrees, based on logger type
+    if hasattr(ds, 'logger_type'):
+        if ds.attrs['logger_type'].upper() == 'CR1000':
+            logger.info('{ds.attrs["logger_type"]} tilt filtered')
+            ds['tilt_x'] = tilt.filter(ds['tilt_x'],
+                                       tilt_threshold)
+            ds['tilt_y'] = tilt.filter(ds['tilt_y'],
+                                       tilt_threshold)
 
-    # Smooth everything
+    # Apply tilt factor if provided (e.g. -1 will invert tilt angle)
+    if hasattr(ds, 'tilt_y_factor'):
+        logger.info('Tilt correction applied based on factor of {ds.attrs["tilt_y_factor"]}')
+        ds['tilt_y'] = tilt.apply_correction(ds['tilt_y'],
+                                             ds.attrs['tilt_y_factor'])
+
+    # Smooth tilt values
     # Note that this should be OK for CR1000 tx (data only every 6 hrs),
     # since we interpolate above in _getTiltDegrees. PJW
-    ds['tilt_x']  = smoothTilt(ds['tilt_x'], 7)                                # Smooth tilt
-    ds['tilt_y']  = smoothTilt(ds['tilt_y'], 7)                               
-    
-    if hasattr(ds, 'bedrock'):                                                 # Fix tilt to zero if station is on bedrock
+    ds['tilt_x'] = tilt.smooth(ds['tilt_x'],
+                               tilt_threshold)
+    ds['tilt_y'] = tilt.smooth(ds['tilt_y'],
+                               tilt_threshold)
+
+    # Fix tilt to zero if station is on bedrock
+    if hasattr(ds, 'bedrock'):
         if ds.attrs['bedrock']==True or ds.attrs['bedrock'].lower() in 'true':
-            ds.attrs['bedrock'] = True                                         # ensures all AWS objects have a 'bedrock' attribute
+
+            # Ensures all passed datasets have a 'bedrock' attribute
+            ds.attrs['bedrock'] = True
+
+            # Assign all tilt values to zero
             ds['tilt_x'] = (('time'), np.arange(ds['time'].size)*0)
             ds['tilt_y'] = (('time'), np.arange(ds['time'].size)*0)
         else:
-            ds.attrs['bedrock'] = False                                        # ensures all AWS objects have a 'bedrock' attribute
+
+            # Ensure all passed datasets have a 'bedrock' attribute
+            ds.attrs['bedrock'] = False
+
+    # Ensure all passed datasets have a 'bedrock' attribute
     else:
-        ds.attrs['bedrock'] = False                                            # ensures all AWS objects have a 'bedrock' attribute
-    
-    if ds.attrs['number_of_booms']==1:                                         # 1-boom processing
-        if ~ds['z_pt'].isnull().all():                                         # Calculate pressure transducer fluid density                                           
-            if hasattr(ds, 'pt_z_offset'):                                     # Apply SR50 stake offset
-                ds['z_pt'] = ds['z_pt'] + int(ds.attrs['pt_z_offset'])              
-            ds['z_pt_cor'],ds['z_pt']=getPressDepth(ds['z_pt'], ds['p_u'], 
-                                                    ds.attrs['pt_antifreeze'], 
-                                                    ds.attrs['pt_z_factor'], 
-                                                    ds.attrs['pt_z_coef'], 
-                                                    ds.attrs['pt_z_p_coef'])       
-        ds['z_stake'] = _reformatArray(ds['z_stake'])                          # Reformat boom height    
-        ds['z_stake'] = ds['z_stake'] * ((ds['t_u'] + T_0)/T_0)**0.5           # Adjust sonic ranger readings for sensitivity to air temperature
-        
-    elif ds.attrs['number_of_booms']==2:                                       # 2-boom processing
-        ds['z_boom_l'] = _reformatArray(ds['z_boom_l'])                        # Reformat boom height    
-        ds['t_l_interp'] = interpTemp(ds['t_l'], vars_df)
-        ds['z_boom_l'] = ds['z_boom_l'] * ((ds['t_l_interp']+ T_0)/T_0)**0.5   # Adjust sonic ranger readings for sensitivity to air temperature    
+        ds.attrs['bedrock'] = False
+
+    # One-boom processing steps, if boom attribute equals 1
+    if ds.attrs['number_of_booms']==1:
+
+        # Apply z_pt (SR50 stake) offset if provided
+        if ~ds['z_pt'].isnull().all():
+            if hasattr(ds, 'pt_z_offset'):
+                ds['z_pt'] = ds['z_pt'] + int(ds.attrs['pt_z_offset'])
+            else:
+                logger.info('pt_z_offset value not provided, therefore no offset applied')
+
+            # Calculate pressure transducer fluid density
+            ds['z_pt_cor'],ds['z_pt']=pressure_depth.correct(ds['z_pt'],
+                                                             ds['p_u'],
+                                                             ds.attrs['pt_antifreeze'],
+                                                             ds.attrs['pt_z_factor'],
+                                                             ds.attrs['pt_z_coef'],
+                                                             ds.attrs['pt_z_p_coef'])
+
+        # Reformat stake boom height
+        ds['z_stake'] = _reformat_array(ds['z_stake'])
+
+        # Correct stake sonic ranger height for air temperature sensitivity
+        ds['z_stake'] = boom_height.correct(ds['z_stake'], ds['t_u'], T_0)
+
+    # Two-boom processing steps, if boom attribute equals 2
+    elif ds.attrs['number_of_booms']==2:
+
+        # Reformat boom height values
+        ds['z_boom_l'] = _reformat_array(ds['z_boom_l'])
+
+        # Correct boom height for air temperature sensitivity
+        ds['z_boom_l'] = boom_height.correct_with_temp_interp(ds['z_boom_l'],
+                                                              ds['t_l'],
+                                                              vars_df,
+                                                              T_0)
 
     ds = clip_values(ds, vars_df)
     for key in ['hygroclip_t_offset', 'dsr_eng_coef', 'usr_eng_coef',
@@ -134,7 +205,7 @@ def toL1(L0, vars_df, T_0=273.15, tilt_threshold=-100):
 
     return ds
 
-def addTimeShift(ds, vars_df):
+def add_time_shift(ds, vars_df):
     '''Shift times based on file format and logger type (shifting only hourly averaged values,
     and not instantaneous variables). For raw (10 min), all values are sampled instantaneously
     so do not shift. For STM (1 hour), values are averaged and assigned to end-of-hour by the
@@ -220,229 +291,7 @@ def addTimeShift(ds, vars_df):
     # ds_out = xr.Dataset(dict(zip(df_out.columns, vals)), attrs=ds.attrs)
     return ds_out
 
-def getPressDepth(z_pt, p, pt_antifreeze, pt_z_factor, pt_z_coef, pt_z_p_coef): 
-    '''Adjust pressure depth and calculate pressure transducer depth based on 
-    pressure transducer fluid density
-    
-    Parameters
-    ----------
-    z_pt : xr.Dataarray
-        Pressure transducer height (corrected for offset)
-    p : xr.Dataarray
-        Air pressure
-    pt_antifreeze : float
-        Pressure transducer anti-freeze percentage for fluid density 
-        correction
-    pt_z_factor : float
-        Pressure transducer factor
-    pt_z_coef : float
-        Pressure transducer coefficient
-    pt_z_p_coef : float
-        Pressure transducer coefficient
-    
-    Returns
-    -------
-    z_pt_cor : xr.Dataarray
-        Pressure transducer height corrected
-    z_pt : xr.Dataarray
-        Pressure transducer depth
-    '''
-    # Calculate pressure transducer fluid density                                        
-    if pt_antifreeze == 50:                                                    #TODO: Implement function w/ reference (analytical or from LUT)                                             
-        rho_af = 1092                                                          #TODO: Track uncertainty
-    elif pt_antifreeze == 100:
-        rho_af = 1145
-    else:
-        rho_af = np.nan
-        logger.info('ERROR: Incorrect metadata: "pt_antifreeze" = ' +
-              f'{pt_antifreeze}. Antifreeze mix only supported at 50% or 100%')
-        # assert(False)
-                
-    # Correct pressure depth
-    z_pt_cor = z_pt * pt_z_coef * pt_z_factor * 998.0 / rho_af + 100 * (pt_z_p_coef - p) / (rho_af * 9.81)
-
-    # Calculate pressure transducer depth
-    z_pt = z_pt * pt_z_coef * pt_z_factor * 998.0 / rho_af
-    
-    return z_pt_cor, z_pt
-
-
-def interpTemp(temp, var_configurations, max_interp=pd.Timedelta(12,'h')):
-    '''Clip and interpolate temperature dataset for use in corrections
-    
-    Parameters
-    ----------
-    temp : `xarray.DataArray`
-        Array of temperature data
-    vars_df : `pandas.DataFrame`
-        Dataframe to retrieve attribute hi-lo values from for temperature clipping
-    max_interp : `pandas.Timedelta`
-        Maximum time steps to interpolate across. The default is 12 hours.
-    
-    Returns
-    -------
-    temp_interp : `xarray.DataArray`
-        Array of interpolatedtemperature data
-    '''
-    # Determine if upper or lower temperature array
-    var = temp.name.lower()
-    
-    # Find range threshold and use it to clip measurements
-    cols = ["lo", "hi", "OOL"]
-    assert set(cols) <= set(var_configurations.columns)
-    variable_limits = var_configurations[cols].dropna(how="all")
-    temp = temp.where(temp >= variable_limits.loc[var,'lo'])
-    temp = temp.where(temp <= variable_limits.loc[var, 'hi'])
-    
-    # Drop duplicates and interpolate across NaN values
-#    temp_interp = temp.drop_duplicates(dim='time', keep='first')
-    temp_interp = temp.interpolate_na(dim='time', max_gap=max_interp)
-    
-    return temp_interp
-
-
-def smoothTilt(tilt, win_size):
-    '''Smooth tilt values using a rolling window. This is translated from the
-    previous IDL/GDL smoothing algorithm:
-    tiltX = smooth(tiltX,7,/EDGE_MIRROR,MISSING=-999) & tiltY = smooth(tiltY,7,/EDGE_MIRROR, MISSING=-999)
-    endif
-    In Python, this should be
-    dstxy = dstxy.rolling(time=7, win_type='boxcar', center=True).mean()
-    But the EDGE_MIRROR makes it a bit more complicated
-    
-    Parameters
-    ----------
-    tilt : xarray.DataArray
-        Array (either 'tilt_x' or 'tilt_y'), tilt values (can be in degrees or voltage)
-    win_size : int
-        Window size to use in pandas 'rolling' method.
-        e.g. a value of 7 spans 70 minutes using 10 minute data.
-
-    Returns
-    -------
-    tdf_rolling : tuple, as: (str, numpy.ndarray)
-        The numpy array is the tilt values, smoothed with a rolling mean
-    '''
-    s = int(win_size/2)
-    tdf = tilt.to_dataframe()
-    mirror_start = tdf.iloc[:s][::-1]
-    mirror_end = tdf.iloc[-s:][::-1]
-    mirrored_tdf = pd.concat([mirror_start, tdf, mirror_end])
-
-    tdf_rolling = (
-        ('time'),
-        mirrored_tdf.rolling(
-            win_size, win_type='boxcar', min_periods=1, center=True
-            ).mean()[s:-s].values.flatten()
-        )
-    return tdf_rolling
-
-def getTiltDegrees(tilt, threshold):
-    '''Filter tilt with given threshold, and convert from voltage to degrees. 
-    Voltage-to-degrees converseion is based on the equation in 3.2.9 at 
-    https://essd.copernicus.org/articles/13/3819/2021/#section3    
-
-    Parameters
-    ----------
-    tilt : xarray.DataArray
-        Array (either 'tilt_x' or 'tilt_y'), tilt values (voltage)
-    threshold : int
-        Values below this threshold (-100) will not be retained.
-    
-    Returns
-    -------
-    dst.interpolate_na() : xarray.DataArray
-        Array (either 'tilt_x' or 'tilt_y'), tilt values (degrees)
-    '''
-    # notOKtiltX = where(tiltX lt -100, complement=OKtiltX) & notOKtiltY = where(tiltY lt -100, complement=OKtiltY)
-    notOKtilt = (tilt < threshold)
-    OKtilt = (tilt >= threshold)
-    tilt = tilt / 10
-    
-    # IDL version:
-    # tiltX = tiltX/10.
-    # tiltnonzero = where(tiltX ne 0 and tiltX gt -40 and tiltX lt 40)
-    # if n_elements(tiltnonzero) ne 1 then tiltX[tiltnonzero] = tiltX[tiltnonzero]/abs(tiltX[tiltnonzero])*(-0.49*(abs(tiltX[tiltnonzero]))^4 + 3.6*(abs(tiltX[tiltnonzero]))^3 - 10.4*(abs(tiltX[tiltnonzero]))^2 +21.1*(abs(tiltX[tiltnonzero])))
-    # tiltY = tiltY/10.
-    # tiltnonzero = where(tiltY ne 0 and tiltY gt -40 and tiltY lt 40)
-    # if n_elements(tiltnonzero) ne 1 then tiltY[tiltnonzero] = tiltY[tiltnonzero]/abs(tiltY[tiltnonzero])*(-0.49*(abs(tiltY[tiltnonzero]))^4 + 3.6*(abs(tiltY[tiltnonzero]))^3 - 10.4*(abs(tiltY[tiltnonzero]))^2 +21.1*(abs(tiltY[tiltnonzero])))
-    
-    dst = tilt
-    nz = (dst != 0) & (np.abs(dst) < 40)
-    
-    dst = dst.where(~nz, other = dst / np.abs(dst)
-                      * (-0.49
-                         * (np.abs(dst))**4 + 3.6
-                         * (np.abs(dst))**3 - 10.4
-                         * (np.abs(dst))**2 + 21.1
-                         * (np.abs(dst))))
-    
-    # if n_elements(OKtiltX) gt 1 then tiltX[notOKtiltX] = interpol(tiltX[OKtiltX],OKtiltX,notOKtiltX) ; Interpolate over gaps for radiation correction; set to -999 again below.
-    dst = dst.where(~notOKtilt)
-    return dst.interpolate_na(dim='time', use_coordinate=False)                #TODO: Filling w/o considering time gaps to re-create IDL/GDL outputs. Should fill with coordinate not False. Also consider 'max_gap' option?
-
-    
-def decodeGPS(ds, gps_names):
-    '''Decode GPS information based on names of GPS attributes. This should be 
-    applied if gps information does not consist of float values
-    
-    Parameters
-    ----------
-    ds : xr.Dataset
-        Data set
-    gps_names : list
-        Variable names for GPS information, such as "gps_lat", "gps_lon" and
-        "gps_alt"
-    
-    Returns
-    -------
-    ds : xr.Dataset
-        Data set with decoded GPS information
-    '''
-    for v in gps_names:
-        a = ds[v].attrs    
-        str2nums = [re.findall(r"[-+]?\d*\.\d+|\d+", _) if isinstance(_, str) else [np.nan] for _ in ds[v].values]
-        ds[v][:] = pd.DataFrame(str2nums).astype(float).T.values[0]
-        ds[v] = ds[v].astype(float)
-        ds[v].attrs = a 
-    return ds
-
-def reformatGPS(pos_arr, attrs):
-    '''Correct latitude and longitude from native format to decimal degrees.
-    
-    v2 stations should send  "NH6429.01544","WH04932.86061" (NUK_L 2022)
-    v3 stations should send coordinates as "6628.93936","04617.59187" (DY2) or 6430,4916 (NUK_Uv3)
-    decodeGPS should have decoded these strings to floats in ddmm.mmmm format
-    v1 stations however only saved decimal minutes (mm.mmmmm) as float<=60. '
-    In this case, we use the integer part of the latitude given in the config 
-    file and append the gps value after it.
-        
-    Parameters
-    ----------
-    pos_arr : xr.Dataarray
-        Array of latitude or longitude measured by the GPS
-    attrs : dict
-        The global attribute 'latitude' or 'longitude' associated with the 
-        file being processed. It is the standard latitude/longitude given in the 
-        config file for that station.
-    
-    Returns
-    -------
-    pos_arr : xr.Dataarray
-        Formatted GPS position array in decimal degree
-    '''       
-    if np.any((pos_arr <= 90) & (pos_arr > 0)):  
-        # then pos_arr is in decimal minutes, so we add to it the integer 
-        # part of the latitude given in the config file x100
-        # so that it reads ddmm.mmmmmm like for v2 and v3 files
-        # Note that np.sign and np.attrs handles negative longitudes.
-        pos_arr = np.sign(attrs) * (pos_arr + 100*np.floor(np.abs(attrs)))
-    a = pos_arr.attrs                                                     
-    pos_arr = np.floor(pos_arr / 100) + (pos_arr / 100 - np.floor(pos_arr / 100)) * 100 / 60
-    pos_arr.attrs = a 
-    return pos_arr 
-
-def _reformatArray(ds_arr):
+def _reformat_array(ds_arr):
     '''Reformat DataArray values and attributes
     
     Parameters
@@ -458,76 +307,7 @@ def _reformatArray(ds_arr):
     a = ds_arr.attrs                                                           # Store
     ds_arr.values = pd.to_numeric(ds_arr, errors='coerce')
     ds_arr.attrs = a                                                           # Reformat
-    return ds_arr         
-
-def _removeVars(ds, v_names):
-    '''Remove redundant variables if present in dataset
-    
-    Parameters
-    ----------
-    ds : xr.Dataset
-        Data set
-    v_names : list
-        List of column names to drop
-    
-    Returns
-    -------
-    ds : xr.Dataset
-        Data set with removed variables
-    '''
-    for v in v_names:
-        if v in list(ds.variables): ds = ds.drop_vars(v)
-    return ds
-
-def _popCols(ds, booms, data_type, vars_df, cols):
-    '''Populate data array columns with given variable names from look-up table
-    
-    Parameters
-    ----------
-    ds : xr.Dataset
-        Data set
-    booms : int
-        Number of booms (1 or 2)
-    data_type : str
-        Type of data ("tx", "raw")
-    vars_df : pd.DataFrame
-        Variables lookup table
-    cols : list
-        Names of columns to populate
-    
-    Returns
-    -------
-    ds : xr.Dataset
-        Data with populated columns
-    '''
-    if booms==1:
-        names = vars_df.loc[(vars_df[cols[0]]!='two-boom')]
-
-    elif booms==2:
-        names = vars_df.loc[(vars_df[cols[0]]!='one-boom')]
-       
-    for v in list(names.index):
-        if v not in list(ds.variables):
-            ds[v] = (('time'), np.arange(ds['time'].size)*np.nan)      
-    return ds
-
-# def _popCols(ds, booms, data_type, vars_df, cols):
-#     if booms==1:
-#         if data_type !='TX':
-#             names = vars_df.loc[(vars_df[cols[0]]!='two-boom')]
-#         else:
-#             names = vars_df.loc[(vars_df[cols[0]] != 'two-boom') & vars_df[cols[1]] != 'tx']
-    
-#     elif booms==2:
-#         if data_type !='TX':
-#             names = vars_df.loc[(vars_df[cols[0]]!='two-boom')]
-#         else:
-#             names = vars_df.loc[(vars_df[cols[0]] != 'two-boom') & vars_df[cols[1]] != 'tx']
-       
-#     for v in list(names.index):
-#         if v not in list(ds.variables):
-#             ds[v] = (('time'), np.arange(ds['time'].size)*np.nan)      
-#     return ds
+    return ds_arr
 
 #------------------------------------------------------------------------------
 

--- a/src/pypromice/process/boom_height/__init__.py
+++ b/src/pypromice/process/boom_height/__init__.py
@@ -1,0 +1,1 @@
+from pypromice.process.boom_height.boom_height import *

--- a/src/pypromice/process/boom_height/boom_height.py
+++ b/src/pypromice/process/boom_height/boom_height.py
@@ -1,0 +1,45 @@
+def correct(z_boom, t, T_0):
+    '''Adjust sonic ranger readings for sensitivity to air temperature'''
+    return z_boom * ((t_interp + T_0) / T_0) ** 0.5
+
+
+def correct_with_temp_interp(z_boom, t, vars_df, T_0):
+    '''Adjust sonic ranger readings for sensitivity to air temperature'''
+    t_interp = _interp_air_temperature(t, vars_df)                          # TODO retire vars_df
+    return z_boom * ((t_interp + T_0) / T_0) ** 0.5
+
+
+def _interpolate_air_temperature(t, var_configurations, max_interp=pd.Timedelta(12, 'h')):      # Move to air temperature submodule? PHO
+    '''Clip and interpolate temperature dataset for use in corrections
+
+    Parameters
+    ----------
+    temp : `xarray.DataArray`
+        Array of temperature data
+    vars_df : `pandas.DataFrame`
+        Dataframe to retrieve attribute hi-lo values from for temperature clipping
+    max_interp : `pandas.Timedelta`
+        Maximum time steps to interpolate across. The default is 12 hours.
+
+    Returns
+    -------
+    temp_interp : `xarray.DataArray`
+        Array of interpolatedtemperature data
+    '''
+    # Determine if upper or lower temperature array
+    var = temp.name.lower()
+
+    # Find range threshold and use it to clip measurements
+    cols = ["lo", "hi", "OOL"]                                      # TODO lo hi values should be explicitly defined here
+    assert set(cols) <= set(var_configurations.columns)
+    variable_limits = var_configurations[cols].dropna(how="all")
+    temp = temp.where(temp >= variable_limits.loc[var, 'lo'])
+    temp = temp.where(temp <= variable_limits.loc[var, 'hi'])
+
+    # Drop duplicates and interpolate across NaN values
+    #    temp_interp = temp.drop_duplicates(dim='time', keep='first')
+    temp_interp = temp.interpolate_na(dim='time', max_gap=max_interp)
+
+    return temp_interp
+
+

--- a/src/pypromice/process/gps/__init__.py
+++ b/src/pypromice/process/gps/__init__.py
@@ -1,0 +1,1 @@
+from pypromice.process.gps.gps import *

--- a/src/pypromice/process/gps/gps.py
+++ b/src/pypromice/process/gps/gps.py
@@ -1,0 +1,64 @@
+import re
+import numpy as np
+import pandas as pd
+
+def decode(gps):
+    '''Decode GPS information based on names of GPS attributes. This should be
+    applied if gps information does not consist of float values
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Data set
+    gps_names : list
+        Variable names for GPS information, such as "gps_lat", "gps_lon" and
+        "gps_alt"
+
+    Returns
+    -------
+    ds : xr.Dataset
+        Data set with decoded GPS information
+    '''
+    a = gps.attrs
+    str2nums = [re.findall(r"[-+]?\d*\.\d+|\d+", _) if isinstance(_, str) else [np.nan] for _ in gps.values]
+    gps[:] = pd.DataFrame(str2nums).astype(float).T.values[0]
+    gps = gps.astype(float)
+    gps.attrs = a
+    return gps
+
+def reformat(pos_arr, attrs):
+    '''Correct latitude and longitude from native format to decimal degrees.
+
+    v2 stations should send  "NH6429.01544","WH04932.86061" (NUK_L 2022)
+    v3 stations should send coordinates as "6628.93936","04617.59187" (DY2) or 6430,4916 (NUK_Uv3)
+    gps.decode should have decoded these strings to floats in ddmm.mmmm format
+    v1 stations however only saved decimal minutes (mm.mmmmm) as float<=60. '
+    In this case, we use the integer part of the latitude given in the config
+    file and append the gps value after it.
+
+    Parameters
+    ----------
+    pos_arr : xr.Dataarray
+        Array of latitude or longitude measured by the GPS
+    attrs : dict
+        The global attribute 'latitude' or 'longitude' associated with the
+        file being processed. It is the standard latitude/longitude given in the
+        config file for that station.
+
+    Returns
+    -------
+    pos_arr : xr.Dataarray
+        Formatted GPS position array in decimal degree
+    '''
+    if np.any((pos_arr <= 90) & (pos_arr > 0)):
+
+        # then pos_arr is in decimal minutes, so we add to it the integer
+        # part of the latitude given in the config file x100
+        # so that it reads ddmm.mmmmmm like for v2 and v3 files
+        # Note that np.sign and np.attrs handles negative longitudes.
+        pos_arr = np.sign(attrs) * (pos_arr + 100 * np.floor(np.abs(attrs)))
+
+    a = pos_arr.attrs
+    pos_arr = np.floor(pos_arr / 100) + (pos_arr / 100 - np.floor(pos_arr / 100)) * 100 / 60
+    pos_arr.attrs = a
+    return pos_arr

--- a/src/pypromice/process/pressure_depth/__init__.py
+++ b/src/pypromice/process/pressure_depth/__init__.py
@@ -1,0 +1,1 @@
+from pypromice.process.pressure_depth.pressure_depth import *

--- a/src/pypromice/process/pressure_depth/pressure_depth.py
+++ b/src/pypromice/process/pressure_depth/pressure_depth.py
@@ -1,0 +1,45 @@
+def correct(z_pt, p, pt_antifreeze, pt_z_factor, pt_z_coef, pt_z_p_coef):
+    '''Adjust pressure depth and calculate pressure transducer depth based on
+    pressure transducer fluid density
+
+    Parameters
+    ----------
+    z_pt : xr.Dataarray
+        Pressure transducer height (corrected for offset)
+    p : xr.Dataarray
+        Air pressure
+    pt_antifreeze : float
+        Pressure transducer anti-freeze percentage for fluid density
+        correction
+    pt_z_factor : float
+        Pressure transducer factor
+    pt_z_coef : float
+        Pressure transducer coefficient
+    pt_z_p_coef : float
+        Pressure transducer coefficient
+
+    Returns
+    -------
+    z_pt_cor : xr.Dataarray
+        Pressure transducer height corrected
+    z_pt : xr.Dataarray
+        Pressure transducer depth
+    '''
+    # Calculate pressure transducer fluid density
+    if pt_antifreeze == 50:  # TODO: Implement function w/ reference (analytical or from LUT)
+        rho_af = 1092  # TODO: Track uncertainty
+    elif pt_antifreeze == 100:
+        rho_af = 1145
+    else:
+        rho_af = np.nan
+        logger.info('ERROR: Incorrect metadata: "pt_antifreeze" = ' +
+                    f'{pt_antifreeze}. Antifreeze mix only supported at 50% or 100%')
+        # assert(False)
+
+    # Correct pressure depth
+    z_pt_cor = z_pt * pt_z_coef * pt_z_factor * 998.0 / rho_af + 100 * (pt_z_p_coef - p) / (rho_af * 9.81)
+
+    # Calculate pressure transducer depth
+    z_pt = z_pt * pt_z_coef * pt_z_factor * 998.0 / rho_af
+
+    return z_pt_cor, z_pt

--- a/src/pypromice/process/radiation/__init__.py
+++ b/src/pypromice/process/radiation/__init__.py
@@ -1,0 +1,1 @@
+from pypromice.process.radiation.radiation import *

--- a/src/pypromice/process/radiation/radiation.py
+++ b/src/pypromice/process/radiation/radiation.py
@@ -1,0 +1,24 @@
+def convert_sr(sr, sr_eng_coef):
+    '''Convert shortwave radiation (upwelling or downwelling) from engineering to physical units'''
+
+    # Can be used to correct both dsr and usr:
+    #     ds['dsr'] = (ds['dsr'] * 10) / ds.attrs['dsr_eng_coef']
+    #     ds['usr'] = (ds['usr'] * 10) / ds.attrs['usr_eng_coef']
+
+    return (sr * 10) / sr_eng_coef
+
+def convert_lr(lr, t_rad, lr_eng_coef, T_0):
+    '''Convert longwave radiation (upwelling or downwelling) from engineering to physical units
+
+    Parameters
+    ----------
+    T_0 : int
+        Air temperature for sonic ranger adjustment. The default is 273.15.
+    '''
+
+    # Can be used to correct both dlr and ulr:
+    # ds['dlr'] = ((ds['dlr'] * 10) / ds.attrs['dlr_eng_coef']) + 5.67E-8 * (ds['t_rad'] + T_0) ** 4
+    # ds['ulr'] = ((ds['ulr'] * 10) / ds.attrs['ulr_eng_coef']) + 5.67E-8 * (ds['t_rad'] + T_0) ** 4
+
+    return ((lr * 10) / lr_eng_coef) + 5.67E-8 * (t_rad + T_0) ** 4
+

--- a/src/pypromice/process/tilt/__init__.py
+++ b/src/pypromice/process/tilt/__init__.py
@@ -1,0 +1,1 @@
+from pypromice.process.tilt.tilt import *

--- a/src/pypromice/process/tilt/tilt.py
+++ b/src/pypromice/process/tilt/tilt.py
@@ -1,0 +1,85 @@
+def smooth(tilt, win_size):
+    '''Smooth tilt values using a rolling window. This is translated from the
+    previous IDL/GDL smoothing algorithm:
+    tiltX = smooth(tiltX,7,/EDGE_MIRROR,MISSING=-999) & tiltY = smooth(tiltY,7,/EDGE_MIRROR, MISSING=-999)
+    endif
+    In Python, this should be
+    dstxy = dstxy.rolling(time=7, win_type='boxcar', center=True).mean()
+    But the EDGE_MIRROR makes it a bit more complicated
+
+    Parameters
+    ----------
+    tilt : xarray.DataArray
+        Array (either 'tilt_x' or 'tilt_y'), tilt values (can be in degrees or voltage)
+    win_size : int
+        Window size to use in pandas 'rolling' method.
+        e.g. a value of 7 spans 70 minutes using 10 minute data.
+
+    Returns
+    -------
+    tdf_rolling : tuple, as: (str, numpy.ndarray)
+        The numpy array is the tilt values, smoothed with a rolling mean
+    '''
+    s = int(win_size / 2)
+    tdf = tilt.to_dataframe()
+    mirror_start = tdf.iloc[:s][::-1]
+    mirror_end = tdf.iloc[-s:][::-1]
+    mirrored_tdf = pd.concat([mirror_start, tdf, mirror_end])
+
+    tdf_rolling = (
+        ('time'),
+        mirrored_tdf.rolling(
+            win_size, win_type='boxcar', min_periods=1, center=True
+        ).mean()[s:-s].values.flatten()
+    )
+    return tdf_rolling
+
+
+def filter(tilt, threshold):                                                    # TODO split this function, one for filtering, one for conversion. PHO.
+    '''Filter tilt with given threshold, and convert from voltage to degrees.
+    Voltage-to-degrees converseion is based on the equation in 3.2.9 at
+    https://essd.copernicus.org/articles/13/3819/2021/#section3
+
+    Parameters
+    ----------
+    tilt : xarray.DataArray
+        Array (either 'tilt_x' or 'tilt_y'), tilt values (voltage)
+    threshold : int
+        Values below this threshold (-100) will not be retained.
+
+    Returns
+    -------
+    dst.interpolate_na() : xarray.DataArray
+        Array (either 'tilt_x' or 'tilt_y'), tilt values (degrees)
+    '''
+    # notOKtiltX = where(tiltX lt -100, complement=OKtiltX) & notOKtiltY = where(tiltY lt -100, complement=OKtiltY)
+    notOKtilt = (tilt < threshold)
+    OKtilt = (tilt >= threshold)
+    tilt = tilt / 10
+
+    # IDL version:
+    # tiltX = tiltX/10.
+    # tiltnonzero = where(tiltX ne 0 and tiltX gt -40 and tiltX lt 40)
+    # if n_elements(tiltnonzero) ne 1 then tiltX[tiltnonzero] = tiltX[tiltnonzero]/abs(tiltX[tiltnonzero])*(-0.49*(abs(tiltX[tiltnonzero]))^4 + 3.6*(abs(tiltX[tiltnonzero]))^3 - 10.4*(abs(tiltX[tiltnonzero]))^2 +21.1*(abs(tiltX[tiltnonzero])))
+    # tiltY = tiltY/10.
+    # tiltnonzero = where(tiltY ne 0 and tiltY gt -40 and tiltY lt 40)
+    # if n_elements(tiltnonzero) ne 1 then tiltY[tiltnonzero] = tiltY[tiltnonzero]/abs(tiltY[tiltnonzero])*(-0.49*(abs(tiltY[tiltnonzero]))^4 + 3.6*(abs(tiltY[tiltnonzero]))^3 - 10.4*(abs(tiltY[tiltnonzero]))^2 +21.1*(abs(tiltY[tiltnonzero])))
+
+    dst = tilt
+    nz = (dst != 0) & (np.abs(dst) < 40)
+
+    dst = dst.where(~nz, other=dst / np.abs(dst)
+                               * (-0.49
+                                  * (np.abs(dst)) ** 4 + 3.6
+                                  * (np.abs(dst)) ** 3 - 10.4
+                                  * (np.abs(dst)) ** 2 + 21.1
+                                  * (np.abs(dst))))
+
+    # if n_elements(OKtiltX) gt 1 then tiltX[notOKtiltX] = interpol(tiltX[OKtiltX],OKtiltX,notOKtiltX) ; Interpolate over gaps for radiation correction; set to -999 again below.
+    dst = dst.where(~notOKtilt)
+    return dst.interpolate_na(dim='time',
+                              use_coordinate=False)  # TODO: Filling w/o considering time gaps to re-create IDL/GDL outputs. Should fill with coordinate not False. Also consider 'max_gap' option?
+
+def apply_correction(tilt, correction_factor):
+    '''Apply tilt factor (e.g. -1 will invert tilt angle)'''
+    return tilt * correction_factor


### PR DESCRIPTION
## Summary of restructuring changes

Restructuring test only performed on `pypromice.process.L0toL1` where:

- Boom height correction for temperature moved to `boom` submodule
- GPS decoding and formating moved to `gps` submodule
- Pressure transducer height correction moved to `pressure_depth` submodule
- Radiometer coefficient corrections moved to `radiation` submodule
- Station inclinometer tilt smoothing and filtering moved to `tilt` submodule

## Notes
- Documentation needs an overhaul, along with general function structuring
- Dataseries are still being overwritten, where a variable is processed and then reassigned the same name. For tracking purposes, we should probably change this.
- xarray Dataseries reformatting is called upon a lot, however should this occur earlier? Such as when loading `L0` dataset with xarray?
- `L0toL1.add_time_shift()` is inherently linked to the logger version. How should we handle this?
- `boom_height.correct_with_temp_interp()` currently calls upon the variables look-up table to retrieve the high and low threshold values. This should not be the case and needs changing

## Idea
Right at the beginning of `L0toL1.toL1()`, we assign the level of processing to the xarray Dataset; like so

```python
ds.attrs['level'] = 'L1'
```

This keeps track of the processing level for an xarray dataset then (i.e. all variables). To implement something where we have processing level assigned to each individual variable, we could explicitly change the level attribute of each variable as it is changed, e.g.

```python
# Correct stake sonic ranger height for air temperature sensitivity
ds['z_stake'] = boom_height.correct(ds['z_stake'], ds['t_u'], T_0)

# Assign level processing to newly processed z_stake variable
ds['z_stake'].attrs['level'] = 'L1'
```