### PR TITLE
Features/automatic dataverse upload with title change

### DIFF
--- a/.github/workflows/dataverse_workflow.yml
+++ b/.github/workflows/dataverse_workflow.yml
@@ -26,10 +26,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install wheel
-          python3 -m pip install --upgrade setuptools
-          cd $GITHUB_WORKSPACE/main
-          pip install .  
-     
+          python3 -m pip install --upgrade setuptools  
+          pip install -U pyDataverse
+          
       - name: Retrieve latest release
       - id: getrelease
         uses: pozetroninc/github-action-get-latest-release@master

--- a/.github/workflows/dataverse_workflow.yml
+++ b/.github/workflows/dataverse_workflow.yml
@@ -36,6 +36,7 @@ jobs:
           
       - name: Send repo to Dataverse
         run: |
+          cd $GITHUB_WORKSPACE
           python3 $GITHUB_WORKSPACE/main/.github/workflows/upload_to_dataverse.py \
           --token "${{secrets.DATAVERSE_TOKEN}}" \
           --server https://dataverse.geus.dk \

--- a/.github/workflows/dataverse_workflow.yml
+++ b/.github/workflows/dataverse_workflow.yml
@@ -27,7 +27,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install wheel requests
           python3 -m pip install --upgrade setuptools  
-          pip install -U pyDataverse
+          pip install -U pyDataverse>=0.3.1
 
       - id: getrelease
         uses: pozetroninc/github-action-get-latest-release@master

--- a/.github/workflows/dataverse_workflow.yml
+++ b/.github/workflows/dataverse_workflow.yml
@@ -8,12 +8,40 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+
     steps:
-      - name: Send repo to Dataverse 
-        uses: IQSS/dataverse-uploader@v1.3
+      - name: Install Python
+        uses: actions/setup-python@v4
         with:
-          DATAVERSE_TOKEN: ${{secrets.DATAVERSE_TOKEN}}
-          DATAVERSE_SERVER: https://dataverse.geus.dk
-          DATAVERSE_DATASET_DOI: doi:10.22008/FK2/3TSBF0
-          DELETE: True
-          PUBLISH: False
+          python-version: "3.10"
+          
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          path: "main"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Install dependencies
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          pip install wheel
+          python3 -m pip install --upgrade setuptools
+          cd $GITHUB_WORKSPACE/main
+          pip install .  
+     
+      - name: Retrieve latest release
+      - id: getrelease
+        uses: pozetroninc/github-action-get-latest-release@master
+        with:
+          repository: GEUS-Glaciology-and-Climate/pypromice
+          
+      - name: Send repo to Dataverse
+        run: |
+          python3 $GITHUB_WORKSPACE/main/.github/workflows/upload_to_dataverse.py \
+          -token ${{secrets.DATAVERSE_TOKEN}} \
+          -server https://dataverse.geus.dk \
+          -doi doi:10.22008/FK2/3TSBF0 \
+          -title ${{ steps.getrelease.outputs.release }} \
+          -remove True \
+          -publish False

--- a/.github/workflows/dataverse_workflow.yml
+++ b/.github/workflows/dataverse_workflow.yml
@@ -28,8 +28,7 @@ jobs:
           pip install wheel
           python3 -m pip install --upgrade setuptools  
           pip install -U pyDataverse
-          
-      - name: Retrieve latest release
+
       - id: getrelease
         uses: pozetroninc/github-action-get-latest-release@master
         with:

--- a/.github/workflows/dataverse_workflow.yml
+++ b/.github/workflows/dataverse_workflow.yml
@@ -40,7 +40,7 @@ jobs:
           --token "${{secrets.DATAVERSE_TOKEN}}" \
           --server https://dataverse.geus.dk \
           --doi doi:10.22008/FK2/3TSBF0 \
-          --title "${{ steps.getrelease.outputs.release }}" \
+          --title "pypromice ${{ steps.getrelease.outputs.release }}" \
           --repo $GITHUB_REPOSITORY \
           --remove True \
           --publish False

--- a/.github/workflows/dataverse_workflow.yml
+++ b/.github/workflows/dataverse_workflow.yml
@@ -37,9 +37,9 @@ jobs:
       - name: Send repo to Dataverse
         run: |
           python3 $GITHUB_WORKSPACE/main/.github/workflows/upload_to_dataverse.py \
-          -token ${{secrets.DATAVERSE_TOKEN}} \
-          -server https://dataverse.geus.dk \
-          -doi doi:10.22008/FK2/3TSBF0 \
-          -title ${{ steps.getrelease.outputs.release }} \
-          -remove True \
-          -publish False
+          ${{secrets.DATAVERSE_TOKEN}} \
+          https://dataverse.geus.dk \
+          doi:10.22008/FK2/3TSBF0 \
+          ${{ steps.getrelease.outputs.release }} \
+          -r True \
+          -p False

--- a/.github/workflows/dataverse_workflow.yml
+++ b/.github/workflows/dataverse_workflow.yml
@@ -44,4 +44,4 @@ jobs:
           --title "pypromice ${{ steps.getrelease.outputs.release }}" \
           --repo $GITHUB_REPOSITORY \
           --remove True \
-          --publish False
+          --publish True

--- a/.github/workflows/dataverse_workflow.yml
+++ b/.github/workflows/dataverse_workflow.yml
@@ -37,9 +37,9 @@ jobs:
       - name: Send repo to Dataverse
         run: |
           python3 $GITHUB_WORKSPACE/main/.github/workflows/upload_to_dataverse.py \
-          ${{secrets.DATAVERSE_TOKEN}} \
-          https://dataverse.geus.dk \
-          doi:10.22008/FK2/3TSBF0 \
-          ${{ steps.getrelease.outputs.release }} \
-          -r True \
-          -p False
+          --token "${{secrets.DATAVERSE_TOKEN}}" \
+          --server https://dataverse.geus.dk \
+          --doi doi:10.22008/FK2/3TSBF0 \
+          --title "${{ steps.getrelease.outputs.release }}" \
+          --remove True \
+          --publish False

--- a/.github/workflows/dataverse_workflow.yml
+++ b/.github/workflows/dataverse_workflow.yml
@@ -36,7 +36,7 @@ jobs:
           
       - name: Send repo to Dataverse
         run: |
-          cd $GITHUB_WORKSPACE
+          cd $GITHUB_WORKSPACE/main
           python3 $GITHUB_WORKSPACE/main/.github/workflows/upload_to_dataverse.py \
           --token "${{secrets.DATAVERSE_TOKEN}}" \
           --server https://dataverse.geus.dk \

--- a/.github/workflows/dataverse_workflow.yml
+++ b/.github/workflows/dataverse_workflow.yml
@@ -41,5 +41,6 @@ jobs:
           --server https://dataverse.geus.dk \
           --doi doi:10.22008/FK2/3TSBF0 \
           --title "${{ steps.getrelease.outputs.release }}" \
+          --repo $GITHUB_REPOSITORY \
           --remove True \
           --publish False

--- a/.github/workflows/dataverse_workflow.yml
+++ b/.github/workflows/dataverse_workflow.yml
@@ -25,7 +25,7 @@ jobs:
         shell: bash
         run: |
           python -m pip install --upgrade pip
-          pip install wheel
+          pip install wheel requests
           python3 -m pip install --upgrade setuptools  
           pip install -U pyDataverse
 

--- a/.github/workflows/upload_to_dataverse.py
+++ b/.github/workflows/upload_to_dataverse.py
@@ -1,7 +1,7 @@
 import argparse
 from time import sleep
 from os.path import join, relpath
-from os import walk
+from os import walk, getcwd
 import requests, json
 from pyDataverse.api import NativeApi
 from pyDataverse.models import Datafile
@@ -78,11 +78,12 @@ if __name__ == '__main__':
                 auth = (token  , ""))
 
     # check if there is a list of dirs to upload
-    paths = ['repo']
+    repo_root = getcwd()
+    paths = [repo_root]
     if args.dir:
         dirs = args.dir.strip().replace(",", " ")
         dirs = dirs.split()
-        paths = [join('repo', d) for d in dirs]
+        paths = [join(repo_root, d) for d in dirs]
 
     # the following adds all files from the repository to Dataverse
     for path in paths:

--- a/.github/workflows/upload_to_dataverse.py
+++ b/.github/workflows/upload_to_dataverse.py
@@ -57,8 +57,9 @@ if __name__ == '__main__':
     args = parse_arguments()
     token = args.token
     dataverse_server = args.server.strip("/")
-    api = NativeApi(dataverse_server , token)
+    print(f"Using Dataverse server: {dataverse_server}")
 
+    api = NativeApi(dataverse_server , token)
     resp = api.get_dataset(args.doi)
     resp.raise_for_status()
     dataset = resp
@@ -126,11 +127,12 @@ if __name__ == '__main__':
         "Content-Type": "application/json",
         "X-Dataverse-key": token
     }
-    url = f"{dataverse_server}/api/datasets/versions/:draft?persistentId={args.doi}&replace=true"
-
-
-    # Send the request
-    resp = requests.put(url, headers=headers, data=json.dumps(updated_metadata))
+    url = f"{dataverse_server}/api/datasets/:persistentId/versions/:draft"
+    params = {
+        "persistentId": args.doi,
+        "replace": "true"
+    }
+    resp = requests.put(url, headers=headers, params=params, data=json.dumps(updated_metadata))
     print("Metadata update response code:", resp.status_code)
     print("Metadata update response body:", resp.text)
 

--- a/.github/workflows/upload_to_dataverse.py
+++ b/.github/workflows/upload_to_dataverse.py
@@ -11,16 +11,16 @@ def parse_arguments():
     parser = argparse.ArgumentParser()
 
     # Mandatory arguments
-    parser.add_argument("token", help="Dataverse token.")
-    parser.add_argument("server", help="Dataverse server.")
-    parser.add_argument("doi", help="Dataset DOI.")
-    parser.add_argument("repo", help="GitHub repository.")
-    parser.add_argument("title", help="Amended title of Dataset.")
+    parser.add_argument("-t", "--token", help="Dataverse token.")
+    parser.add_argument("-s","--server", help="Dataverse server.")
+    parser.add_argument("-d", "--doi", help="Dataset DOI.")
+    parser.add_argument("-r", "--repo", help="GitHub repository.")
+    parser.add_argument("-e", "--title", help="Amended title of Dataset.")
 
     # Optional arguments
-    parser.add_argument("-d", "--dir", help="Uploads only a specific dir.")
+    parser.add_argument("-i", "--dir", help="Uploads only a specific dir.")
     parser.add_argument(
-        "-r", "--remove", help="Remove (delete) all files before upload.", \
+        "-v", "--remove", help="Remove (delete) all files before upload.", \
         choices=('True', 'TRUE', 'true', 'False', 'FALSE', 'false'), \
         default='true')
     parser.add_argument(

--- a/.github/workflows/upload_to_dataverse.py
+++ b/.github/workflows/upload_to_dataverse.py
@@ -105,7 +105,7 @@ if __name__ == '__main__':
     for m in metadata["fields"]:
         if 'title' in m['typeName']:
             m.update({'value': 'test'})
-    resp = api.edit_dataset_metadata(args.doi, metadata, is_replace=True, auth=True)
+    resp = api.edit_dataset_metadata(args.doi, metadata, replace=True, auth=True)
     print(resp.status_code)
 
     if args.publish.lower() == 'true':

--- a/.github/workflows/upload_to_dataverse.py
+++ b/.github/workflows/upload_to_dataverse.py
@@ -1,0 +1,113 @@
+import argparse
+from time import sleep
+from os.path import join
+from os import walk
+import requests
+from pyDataverse.api import NativeApi
+from pyDataverse.models import Datafile
+
+def parse_arguments():
+    """ Parses cmd-line arguments """
+    parser = argparse.ArgumentParser()
+
+    # Mandatory arguments
+    parser.add_argument("token", help="Dataverse token.")
+    parser.add_argument("server", help="Dataverse server.")
+    parser.add_argument("doi", help="Dataset DOI.")
+    parser.add_argument("repo", help="GitHub repository.")
+    parser.add_argument("title", help="Amended title of Dataset.")
+
+    # Optional arguments
+    parser.add_argument("-d", "--dir", help="Uploads only a specific dir.")
+    parser.add_argument(
+        "-r", "--remove", help="Remove (delete) all files before upload.", \
+        choices=('True', 'TRUE', 'true', 'False', 'FALSE', 'false'), \
+        default='true')
+    parser.add_argument(
+        "-p", "--publish", help="Publish a new dataset version after upload.", \
+        choices=('True', 'TRUE', 'true', 'False', 'FALSE', 'false'), \
+        default='false')
+
+    args_ = parser.parse_args()
+    return args_
+
+
+def check_dataset_lock(num):
+    """ Gives Dataverse server more time for upload """
+    if num <= 1:
+        print('Lock found for dataset id ' + \
+          str(dataset_dbid) + '\nTry again later!')
+        return
+
+    query_str = dataverse_server + \
+         '/api/datasets/' + str(dataset_dbid) + '/locks/'
+    resp_ = requests.get(query_str, auth = (token, ""))
+    locks = resp_.json()['data']
+
+    if bool(locks):
+        print('Lock found for dataset id ' + \
+           str(dataset_dbid) + '\n... sleeping...')
+        sleep(2)
+        check_dataset_lock(num-1)
+    return
+
+
+if __name__ == '__main__':
+
+    args = parse_arguments()
+    token = args.token
+    dataverse_server = args.server.strip("/")
+    api = NativeApi(dataverse_server , token)
+
+    dataset = api.get_dataset(args.doi)
+    files_list = dataset.json()['data']['latestVersion']['files']
+    dataset_dbid = dataset.json()['data']['id']
+
+    if args.remove.lower() == 'true':
+        # the following deletes all the files in the dataset
+        delete_api = dataverse_server + \
+            '/dvn/api/data-deposit/v1.1/swordv2/edit-media/file/'
+        for f in files_list:
+            fileid = f["dataFile"]["id"]
+            resp = requests.delete(
+                delete_api + str(fileid), \
+                auth = (token  , ""))
+
+    # check if there is a list of dirs to upload
+    paths = ['repo']
+    if args.dir:
+        dirs = args.dir.strip().replace(",", " ")
+        dirs = dirs.split()
+        paths = [join('repo', d) for d in dirs]
+
+    # the following adds all files from the repository to Dataverse
+    for path in paths:
+        for root, subdirs, files in walk(path):
+            if '.git' in subdirs:
+                subdirs.remove('.git')
+            if '.github' in subdirs:
+                subdirs.remove('.github')
+            for f in files:
+                df = Datafile()
+                df.set({
+                    "pid" : args.doi,
+                    "filename" : f,
+                    "directoryLabel": root[5:],
+                    "description" : \
+                      "Uploaded with GitHub Action from {}.".format(
+                        args.repo),
+                    })
+                resp = api.upload_datafile(
+                    args.doi, join(root,f), df.json())
+                check_dataset_lock(5)
+
+    metadata = dataset.json()["data"]["latestVersion"]["metadataBlocks"]["citation"]
+    for m in metadata["fields"]:
+        if 'title' in m['typeName']:
+            m.update({'value': 'test'})
+    resp = api.edit_dataset_metadata(args.doi, metadata, is_replace=True, auth=True)
+    print(resp.status_code)
+
+    if args.publish.lower() == 'true':
+        # publish updated dataset
+        resp = api.publish_dataset(args.doi, release_type="major")


### PR DESCRIPTION
- The automatic dataverse upload that copies a new pypromice release to the GEUS Dataverse entry currently does not support the title being updated to reflect the most up-to-date version
- As a result, we currently have to perform the upload and then enter the Dataverse draft and manually update the title
- In this update, I have changed this so that the title of the Dataverse is updated automatically, by fetching the tag (e.g. `v1.5.3`) of the latest release
- At the moment, this still does not publish automatically. I want to see how it performs when the next pypromice release is made. Once we are happy that it performs properly, then we can switch the flag in the .yml action file to publish automatically 