### PR TITLE
Update `file_attributes.csv` values and fix typos

### DIFF
--- a/src/pypromice/resources/file_attributes.csv
+++ b/src/pypromice/resources/file_attributes.csv
@@ -3,7 +3,7 @@ acknowledgements,The Programme for Monitoring of the Greenland Ice Sheet (PROMIC
 alt.axis,Z
 alt.coverage_content_type,coordinate
 gps_alt.positive,up
-cdm_data_type,
+cdm_data_type,Station
 comment,https://doi.org/10.22008/promice/data/aws
 contributor_name,
 contributor_role,

--- a/src/pypromice/resources/file_attributes.csv
+++ b/src/pypromice/resources/file_attributes.csv
@@ -22,7 +22,7 @@ geospatial_lon_extents_match,gps_lon
 geospatial_lon_resolution,
 geospatial_lon_units,degrees_east
 geospatial_vertical_resolution,
-geospatial_vertical_units,EPSG:4979
+geospatial_vertical_units,meters
 institution,Geological Survey of Denmark and Greenland (GEUS)
 instrument,See https://doi.org/10.5194/essd-13-3819-2021
 instrument_vocabulary,GCMD:GCMD Keywords

--- a/src/pypromice/resources/file_attributes.csv
+++ b/src/pypromice/resources/file_attributes.csv
@@ -8,8 +8,8 @@ comment,https://doi.org/10.22008/promice/data/aws
 contributor_name,
 contributor_role,
 conventions,ACDD-1.3; CF-1.7
-creater_email,pho@geus.dk
-creater_url,https://promice.dk
+creator_email,pho@geus.dk
+creator_url,https://promice.dk
 creator_institution,Geological Survey of Denmark and Greenland (GEUS)
 creator_name,Penelope How
 creator_type,person


### PR DESCRIPTION
### Description

This pull request includes the following changes:

- Updated `geospatial_vertical_units` in `file_attributes.csv` to "meters".
- Corrected typos in field names (`creater_email` → `creator_email`, `creater_url` → `creator_url`) in `file_attributes.csv`.
- Updated the `cdm_data_type` field in `file_attributes.csv` to "Station"

The cdm_data_type attribute describes the fundamental organization of the data within the file according to the Climate and Forecast (CF) / Attribute Convention for Dataset Discovery (ACDD). It helps clients and tools understand whether the data represent a grid, trajectory, time series, station, swath, etc.

