### PR TITLE
renaming OOL to dependent_variables + set dependencies

### DIFF
--- a/src/pypromice/core/qc/value_clipping.py
+++ b/src/pypromice/core/qc/value_clipping.py
@@ -24,11 +24,11 @@ def clip_values(
     ds : `xarray.Dataset`
         Dataset with clipped data
     """
-    cols = ["lo", "hi", "OOL"]
+    cols = ["lo", "hi", "dependent_variables"]
     assert set(cols) <= set(var_configurations.columns)
 
     variable_limits = var_configurations[cols].assign(
-        dependents=lambda df: df.OOL.fillna("").str.split(),
+        dependents=lambda df: df.dependent_variables.fillna("").str.split(),
         # Find the closure of dependents using the DependencyGraph class
         dependents_closure=lambda df: DependencyGraph.from_child_mapping(
             df.dependents

--- a/src/pypromice/resources/variables.csv
+++ b/src/pypromice/resources/variables.csv
@@ -33,25 +33,25 @@ dlhf_u,surface_downward_latent_heat_flux,Latent heat flux (upper boom),W m-2,mod
 dlhf_l,surface_downward_latent_heat_flux,Latent heat flux (lower boom),W m-2,modelResult,time,FALSE,L3 or later,,,,two-boom,0,0,1,4
 dshf_u,surface_downward_sensible_heat_flux,Sensible heat flux (upper boom),W m-2,modelResult,time,FALSE,L3 or later,,,,all,0,0,1,4
 dshf_l,surface_downward_sensible_heat_flux,Sensible heat flux (lower boom),W m-2,modelResult,time,FALSE,L3 or later,,,,two-boom,0,0,1,4
-z_boom_u,distance_to_surface_from_boom,Upper boom height,m,physicalMeasurement,time,TRUE,,0.3,10,"",all,1,1,1,4
+z_boom_u,distance_to_surface_from_boom,Upper boom height,m,physicalMeasurement,time,TRUE,,0.3,10,z_boom_cor_u,all,1,1,1,4
 z_boom_cor_u,distance_to_surface_from_boom_corrected,Upper boom height - corrected,m,modelResult,time,TRUE,,0.3,10,"",all,1,1,1,4
 z_boom_q_u,distance_to_surface_from_boom_quality,Upper boom height (quality),-,qualityInformation,time,TRUE,L0 or L2,,,,all,1,1,0,4
-z_boom_l,distance_to_surface_from_boom,Lower boom height,m,physicalMeasurement,time,TRUE,,0.3,5,"",two-boom,1,1,1,4
+z_boom_l,distance_to_surface_from_boom,Lower boom height,m,physicalMeasurement,time,TRUE,,0.3,5,z_boom_cor_l,two-boom,1,1,1,4
 z_boom_cor_l,distance_to_surface_from_boom_corrected,Lower boom height - corrected,m,modelResult,time,TRUE,,0.3,5,"",two-boom,1,1,1,4
 z_boom_q_l,distance_to_surface_from_boom_quality,Lower boom height (quality),-,qualityInformation,time,TRUE,L0 or L2,,,,two-boom,1,1,0,4
-z_stake,distance_to_surface_from_stake_assembly,Stake height,m,physicalMeasurement,time,TRUE,,0.3,8,,one-boom,1,1,1,4
+z_stake,distance_to_surface_from_stake_assembly,Stake height,m,physicalMeasurement,time,TRUE,,0.3,8,z_stake_cor,one-boom,1,1,1,4
 z_stake_cor,distance_to_surface_from_stake_assembly_corrected,Stake height - corrected,m,physicalMeasurement,time,TRUE,,0.3,8,,one-boom,1,1,1,4
 z_stake_q,distance_to_surface_from_stake_assembly_quality,Stake height (quality),-,qualityInformation,time,TRUE,L0 or L2,,,,one-boom,1,1,0,4
-z_pt,depth_of_pressure_transducer_in_ice,Depth of pressure transducer in ice,m,physicalMeasurement,time,FALSE,,0,30,"",one-boom,1,1,1,4
+z_pt,depth_of_pressure_transducer_in_ice,Depth of pressure transducer in ice,m,physicalMeasurement,time,FALSE,,0,30,z_pt_cor,one-boom,1,1,1,4
 z_pt_cor,depth_of_pressure_transducer_in_ice_corrected,Depth of pressure transducer in ice - corrected,m,modelResult,time,FALSE,L2 or later,0,30,,one-boom,0,1,1,4
 z_surf_combined,height_of_surface_combined,"Surface height combined from multiple sensors, relative to ice surface height at installation",m,modelResult,time,FALSE,L3,,,,all,0,0,1,4
 z_ice_surf,height_of_ice_surface,"Ice surface height, relative to ice surface height at installation and calculated from pt_cor and z_stake",m,modelResult,time,FALSE,L3,,,,one-boom,0,0,1,4
 snow_height,height_of_snow,"Snow surface height, relative to ice surface",m,modelResult,time,FALSE,L3,0,,,one-boom,0,0,1,4
 precip_u,precipitation_raw_upper,Semi-accumulated uncorrected liquid precipitation (upper boom),mm,physicalMeasurement,time,TRUE,L0 or L2,0,,rainfall_u,all,1,1,0,4
-rainfall_u,rainfall_per_timestep_uncorrected_upper,Rainfall within timestep uncorrected for undercatch (upper boom),mm,modelResult,time,FALSE,L2 or later,0,,,all,0,1,1,4
+rainfall_u,rainfall_per_timestep_uncorrected_upper,Rainfall within timestep uncorrected for undercatch (upper boom),mm,modelResult,time,FALSE,L2 or later,0,,rainfall_cor_u,all,0,1,1,4
 rainfall_cor_u,rainfall_per_timestep_corrected_upper,Rainfall within timestep corrected for undercatch (upper boom),mm,modelResult,time,FALSE,L2 or later,0,,,all,0,1,1,4
 precip_l,precipitation_raw_lower,Semi-accumulated uncorrected liquid precipitation (lower boom),mm,physicalMeasurement,time,TRUE,L0 or L2,0,,rainfall_l,two-boom,1,1,0,4
-rainfall_l,rainfall_per_timestep_uncorrected_lower,Rainfall within timestep uncorrected for undercatch (lower boom),mm,modelResult,time,FALSE,L2 or later,0,,,all,0,1,1,4
+rainfall_l,rainfall_per_timestep_uncorrected_lower,Rainfall within timestep uncorrected for undercatch (lower boom),mm,modelResult,time,FALSE,L2 or later,0,,rainfall_cor_l,all,0,1,1,4
 rainfall_cor_l,rainfall_per_timestep_corrected_lower,Rainfall within timestep corrected for undercatch (lower boom),mm,modelResult,time,FALSE,L2 or later,0,,,all,0,1,1,4
 t_i_1,ice_temperature_at_t1,Ice temperature at sensor 1,degrees_C,physicalMeasurement,time,FALSE,,-80,1,,all,1,1,1,4
 t_i_2,ice_temperature_at_t2,Ice temperature at sensor 2,degrees_C,physicalMeasurement,time,FALSE,,-80,1,,all,1,1,1,4

--- a/src/pypromice/resources/variables.csv
+++ b/src/pypromice/resources/variables.csv
@@ -1,18 +1,18 @@
-field,standard_name,long_name,units,coverage_content_type,coordinates,instantaneous_hourly,where_to_find,lo,hi,OOL,station_type,L0,L2,L3,max_decimals
+field,standard_name,long_name,units,coverage_content_type,coordinates,instantaneous_hourly,where_to_find,lo,hi,dependent_variables,station_type,L0,L2,L3,max_decimals
 time,time,Time,yyyy-mm-dd HH:MM:SS,physicalMeasurement,time,,,,,,all,1,1,1,
 rec,record,Record,-,referenceInformation,time,,L0 or L2,,,,all,1,1,0,0
-p_u,air_pressure,Air pressure (upper boom),hPa,physicalMeasurement,time,FALSE,,650,1100,"",all,1,1,1,4
-p_l,air_pressure,Air pressure (lower boom),hPa,physicalMeasurement,time,FALSE,,650,1100,"",two-boom,1,1,1,4
-t_u,air_temperature,Air temperature (upper boom),degrees_C,physicalMeasurement,time,FALSE,,-80,40,"",all,1,1,1,4
-t_l,air_temperature,Air temperature (lower boom),degrees_C,physicalMeasurement,time,FALSE,,-80,40,"",two-boom,1,1,1,4
-rh_u,relative_humidity,Relative humidity (upper boom),%,physicalMeasurement,time,FALSE,,0,100,"",all,1,1,1,4
+p_u,air_pressure,Air pressure (upper boom),hPa,physicalMeasurement,time,FALSE,,650,1100,z_pt_cor dlhf_u dshf_u,all,1,1,1,4
+p_l,air_pressure,Air pressure (lower boom),hPa,physicalMeasurement,time,FALSE,,650,1100,dlhf_l dshf_l,two-boom,1,1,1,4
+t_u,air_temperature,Air temperature (upper boom),degrees_C,physicalMeasurement,time,FALSE,,-80,40,z_boom_cor_l z_boom_cor_u z_stake_cor qh_u rh_u_wrt_ice_or_water dlhf_u dshf_u,all,1,1,1,4
+t_l,air_temperature,Air temperature (lower boom),degrees_C,physicalMeasurement,time,FALSE,,-80,40,dlhf_l dshf_l,two-boom,1,1,1,4
+rh_u,relative_humidity,Relative humidity (upper boom),%,physicalMeasurement,time,FALSE,,0,100,qh_u rh_u_wrt_ice_or_water dlhf_u dshf_u,all,1,1,1,4
 rh_u_wrt_ice_or_water,relative_humidity_with_respect_to_ice_or_water,Relative humidity (upper boom) with respect to saturation over ice in subfreezing conditions and over water otherwise,%,modelResult,time,FALSE,L2 or later,0,150,"",all,0,1,1,4
 qh_u,specific_humidity,Specific humidity (upper boom),kg/kg,modelResult,time,FALSE,L2 or later,0,100,"",all,0,1,1,4
-rh_l,relative_humidity,Relative humidity (lower boom),%,physicalMeasurement,time,FALSE,,0,100,"",two-boom,1,1,1,4
+rh_l,relative_humidity,Relative humidity (lower boom),%,physicalMeasurement,time,FALSE,,0,100,qh_l rh_l_wrt_ice_or_water dlhf_l dshf_l,two-boom,1,1,1,4
 rh_l_wrt_ice_or_water,relative_humidity_with_respect_to_ice_or_water,Relative humidity (lower boom) with respect to saturation over ice in subfreezing conditions and over water otherwise,%,modelResult,time,FALSE,L2 or later,0,150,"",two-boom,0,1,1,4
 qh_l,specific_humidity,Specific humidity (lower boom),kg/kg,modelResult,time,FALSE,L2 or later,0,100,,two-boom,0,1,1,4
-wspd_u,wind_speed,Wind speed (upper boom),m s-1,physicalMeasurement,time,FALSE,,0,100,wdir_u wspd_x_u wspd_y_u,all,1,1,1,4
-wspd_l,wind_speed,Wind speed (lower boom),m s-1,physicalMeasurement,time,FALSE,,0,100,wdir_l wspd_x_l wspd_y_l,two-boom,1,1,1,4
+wspd_u,wind_speed,Wind speed (upper boom),m s-1,physicalMeasurement,time,FALSE,,0,100,wdir_u wspd_x_u wspd_y_u rainfall_cor_u,all,1,1,1,4
+wspd_l,wind_speed,Wind speed (lower boom),m s-1,physicalMeasurement,time,FALSE,,0,100,wdir_l wspd_x_l wspd_y_l rainfall_cor_l,two-boom,1,1,1,4
 wdir_u,wind_from_direction,Wind from direction (upper boom),degrees,physicalMeasurement,time,FALSE,,1,360,wspd_x_u wspd_y_u,all,1,1,1,4
 wdir_std_u,wind_from_direction_standard_deviation,Wind from direction (standard deviation),degrees,qualityInformation,time,FALSE,L0 or L2,,,,one-boom,1,1,0,4
 wdir_l,wind_from_direction,Wind from direction (lower boom),degrees,physicalMeasurement,time,FALSE,,1,360,wspd_x_l wspd_y_l,two-boom,1,1,1,4
@@ -47,10 +47,10 @@ z_pt_cor,depth_of_pressure_transducer_in_ice_corrected,Depth of pressure transdu
 z_surf_combined,height_of_surface_combined,"Surface height combined from multiple sensors, relative to ice surface height at installation",m,modelResult,time,FALSE,L3,,,,all,0,0,1,4
 z_ice_surf,height_of_ice_surface,"Ice surface height, relative to ice surface height at installation and calculated from pt_cor and z_stake",m,modelResult,time,FALSE,L3,,,,one-boom,0,0,1,4
 snow_height,height_of_snow,"Snow surface height, relative to ice surface",m,modelResult,time,FALSE,L3,0,,,one-boom,0,0,1,4
-precip_u,precipitation_raw_upper,Semi-accumulated uncorrected liquid precipitation (upper boom),mm,physicalMeasurement,time,TRUE,L0 or L2,0,,"",all,1,1,0,4
+precip_u,precipitation_raw_upper,Semi-accumulated uncorrected liquid precipitation (upper boom),mm,physicalMeasurement,time,TRUE,L0 or L2,0,,rainfall_u,all,1,1,0,4
 rainfall_u,rainfall_per_timestep_uncorrected_upper,Rainfall within timestep uncorrected for undercatch (upper boom),mm,modelResult,time,FALSE,L2 or later,0,,,all,0,1,1,4
 rainfall_cor_u,rainfall_per_timestep_corrected_upper,Rainfall within timestep corrected for undercatch (upper boom),mm,modelResult,time,FALSE,L2 or later,0,,,all,0,1,1,4
-precip_l,precipitation_raw_lower,Semi-accumulated uncorrected liquid precipitation (lower boom),mm,physicalMeasurement,time,TRUE,L0 or L2,0,,"",two-boom,1,1,0,4
+precip_l,precipitation_raw_lower,Semi-accumulated uncorrected liquid precipitation (lower boom),mm,physicalMeasurement,time,TRUE,L0 or L2,0,,rainfall_l,two-boom,1,1,0,4
 rainfall_l,rainfall_per_timestep_uncorrected_lower,Rainfall within timestep uncorrected for undercatch (lower boom),mm,modelResult,time,FALSE,L2 or later,0,,,all,0,1,1,4
 rainfall_cor_l,rainfall_per_timestep_corrected_lower,Rainfall within timestep corrected for undercatch (lower boom),mm,modelResult,time,FALSE,L2 or later,0,,,all,0,1,1,4
 t_i_1,ice_temperature_at_t1,Ice temperature at sensor 1,degrees_C,physicalMeasurement,time,FALSE,,-80,1,,all,1,1,1,4
@@ -76,8 +76,8 @@ d_t_i_9,depth_of_thermistor_9,Depth of thermistor 9,m,modelResult,time,FALSE,L3,
 d_t_i_10,depth_of_thermistor_10,Depth of thermistor 10,m,modelResult,time,FALSE,L3,-10,100,,two-boom,0,0,1,4
 d_t_i_11,depth_of_thermistor_11,Depth of thermistor 11,m,modelResult,time,FALSE,L3,-10,100,,two-boom,0,0,1,4
 t_i_10m,10m_subsurface_temperature,10 m subsurface temperature,degrees_C,modelResult,time,FALSE,L3,-70,0,,all,0,0,1,4
-tilt_x,platform_view_angle_x,Tilt to east,degrees,physicalMeasurement,time,FALSE,,-30,30,"",all,1,1,1,4
-tilt_y,platform_view_angle_y,Tilt to north,degrees,physicalMeasurement,time,FALSE,,-30,30,"",all,1,1,1,4
+tilt_x,platform_view_angle_x,Tilt to east,degrees,physicalMeasurement,time,FALSE,,-30,30,dsr_cor usr_cor,all,1,1,1,4
+tilt_y,platform_view_angle_y,Tilt to north,degrees,physicalMeasurement,time,FALSE,,-30,30,dsr_cor usr_cor,all,1,1,1,4
 rot,platform_azimuth_angle,Station rotation from true North,degrees,physicalMeasurement,time,FALSE,,0,360,,all,1,1,1,2
 gps_lat,gps_latitude,Latitude,degrees_north,physicalMeasurement,time,TRUE,,50,83,,all,1,1,1,6
 gps_lon,gps_longitude,Longitude,degrees_east,physicalMeasurement,time,TRUE,,5,70,,all,1,1,1,6
@@ -98,10 +98,10 @@ fan_dc_u,fan_current,Fan current (upper boom),mA,physicalMeasurement,time,TRUE,L
 fan_dc_l,fan_current,Fan current (lower boom),mA,physicalMeasurement,time,TRUE,,0,200,,two-boom,1,1,0,2
 freq_vw,frequency_of_precipitation_wire_vibration,Frequency of vibrating wire in precipitation gauge,Hz,physicalMeasurement,time,TRUE,L0 or L2,0,10000,"",,1,1,0,
 t_log,temperature_of_logger,Logger temperature,degrees_C,physicalMeasurement,time,TRUE,,-80,40,,one-boom,1,1,0,4
-t_rad,temperature_of_radiation_sensor,Radiation sensor temperature,degrees_C,physicalMeasurement,time,FALSE,,-80,40,"",all,1,1,1,4
+t_rad,temperature_of_radiation_sensor,Radiation sensor temperature,degrees_C,physicalMeasurement,time,FALSE,,-80,40,dlr ulr,all,1,1,1,4
 p_i,air_pressure,Air pressure (instantaneous) minus 1000,hPa,physicalMeasurement,time,TRUE,,-350,100,,all,1,1,1,4
-t_i,air_temperature,Air temperature (instantaneous),degrees_C,physicalMeasurement,time,TRUE,,-80,40,,all,1,1,1,4
-rh_i,relative_humidity,Relative humidity (instantaneous),%,physicalMeasurement,time,TRUE,,0,150,"",all,1,1,1,4
+t_i,air_temperature,Air temperature (instantaneous),degrees_C,physicalMeasurement,time,TRUE,,-80,40,rh_i_wrt_ice_or_water,all,1,1,1,4
+rh_i,relative_humidity,Relative humidity (instantaneous),%,physicalMeasurement,time,TRUE,,0,150,rh_i_wrt_ice_or_water,all,1,1,1,4
 rh_i_wrt_ice_or_water,relative_humidity_with_respect_to_ice_or_water,Relative humidity (instantaneous) with respect to saturation over ice in subfreezing conditions and over water otherwise,%,modelResult,time,TRUE,L2 or later,0,100,,all,0,1,1,4
 wspd_i,wind_speed,Wind speed (instantaneous),m s-1,physicalMeasurement,time,TRUE,,0,100,wdir_i wspd_x_i wspd_y_i,all,1,1,1,4
 wdir_i,wind_from_direction,Wind from direction (instantaneous),degrees,physicalMeasurement,time,TRUE,,1,360,wspd_x_i wspd_y_i,all,1,1,1,4

--- a/tests/unit/test_value_clippping.py
+++ b/tests/unit/test_value_clippping.py
@@ -130,7 +130,7 @@ class ClipValuesTestCase(unittest.TestCase):
     def test_recursive_flagging(self):
         fields = ["a", "b", "c"]
         variable_config = pd.DataFrame(
-            columns=["field", "lo", "hi", "OOL"],
+            columns=["field", "lo", "hi", "dependent_variables"],
             data=[
                 ["a", 0, 10, "b"],
                 ["b", 100, 110, ""],
@@ -176,7 +176,7 @@ class ClipValuesTestCase(unittest.TestCase):
     def test_circular_dependencies(self):
         fields = ["a", "b", "c"]
         variable_config = pd.DataFrame(
-            columns=["field", "lo", "hi", "OOL"],
+            columns=["field", "lo", "hi", "dependent_variables"],
             data=[
                 ["a", 0, 10, "b"],
                 ["b", 100, 110, "c"],
@@ -222,7 +222,7 @@ class ClipValuesTestCase(unittest.TestCase):
 
     def test_rh_adjusted(self):
         variable_config = pd.DataFrame(
-            columns=["field", "lo", "hi", "OOL"],
+            columns=["field", "lo", "hi", "dependent_variables"],
             data=[
                 ["rh_u", 0, 150, "rh_u_wrt_ice_or_water"],
                 ["rh_u_wrt_ice_or_water", 0, 150, ""],
@@ -234,13 +234,13 @@ class ClipValuesTestCase(unittest.TestCase):
         # All values are within the expected range
         rows_input.append(dict(rh_u=42, rh_u_wrt_ice_or_water=43))
         rows_expected.append(dict(rh_u=42, rh_u_wrt_ice_or_water=43))
-        # rh_u is below range, but rh_u_wrt_ice_or_water is within range. Both should be flagged due to the OOL relationship
+        # rh_u is below range, but rh_u_wrt_ice_or_water is within range. Both should be flagged due to the variable dependency.
         rows_input.append(dict(rh_u=-10, rh_u_wrt_ice_or_water=3))
         rows_expected.append(dict(rh_u=np.nan, rh_u_wrt_ice_or_water=np.nan))
         # rh_u is within range, but rh_u_wrt_ice_or_water is below range; rh_u_wrt_ice_or_water should be flagged
         rows_input.append(dict(rh_u=54, rh_u_wrt_ice_or_water=-4))
         rows_expected.append(dict(rh_u=54, rh_u_wrt_ice_or_water=np.nan))
-        # rh_u is above range, but rh_u_wrt_ice_or_water is within range. Both should be flagged due to the OOL relationship
+        # rh_u is above range, but rh_u_wrt_ice_or_water is within range. Both should be flagged due to the variable dependency.
         rows_input.append(dict(rh_u=160, rh_u_wrt_ice_or_water=120))
         rows_expected.append(dict(rh_u=np.nan, rh_u_wrt_ice_or_water=np.nan))
         # rh_u is within range, but rh_u_wrt_ice_or_water is above range; rh_u_wrt_ice_or_water should be flagged
@@ -269,7 +269,7 @@ class ClipValuesTestCase(unittest.TestCase):
         """
         fields = ["a", "b"]
         variable_config = pd.DataFrame(
-            columns=["field", "lo", "hi", "OOL"],
+            columns=["field", "lo", "hi", "dependent_variables"],
             data=[
                 ["a", 0, 10, "b"],
                 ["b", 100, 110, ""],


### PR DESCRIPTION
First of all, OOL originally stood for "out of limit". I don't know how it eventually got used to map variable dependencies.

For many variables we were:
1) correcting (e.g. `z_pt` with `p_u` creating `z_pt_cor`)
2) filtering (e.g. on bad `p_u`)
3) failed to set the dependency between an input variable (`p_u`) and a corrected/dependent variable (e.g. `z_pt_cor`)

Note that only strict dependencies should be informed there (where NaN in input should be NaN in derived variable).
For variables like `z_surf_combined` `snow_height` `d_t_i_*` interpolations within the derivation can lead to non-NaN values when inputs have NaNs. 

New behavior:
<img width="1003" height="857" alt="billede" src="https://github.com/user-attachments/assets/5b5fe3fa-1175-4ad2-8e1a-7adf36e98eb1" />
Old behavior would be that the outliers in z_pt_cor would remain.

@PennyHow, @ladsmund  any objection?