### PR TITLE
fixed level 2 merging of precip

### DIFF
--- a/src/pypromice/pipeline/join_l2.py
+++ b/src/pypromice/pipeline/join_l2.py
@@ -65,26 +65,18 @@ def join_l2(file1,file2,outpath,variables,metadata) -> xr.Dataset:
             logger.info(f'Combining {file1} with {file2}...')
             name = n1
             all_ds = ds1.combine_first(ds2)
-
-            # Re-calculate corrected precipitation
+            
+            # combine_first works terrible for accumulated values
+            # we rather combine semi-accumulated precipitation in block
             for var in ['precip_u', 'precip_l']:
                 if hasattr(all_ds, var):
                     if all_ds[var].notnull().any():
-                        # combine_first works terrible for accumulated values
-                        # we rather combine accumulated precipitation in block
                         tx_data_no_overlap =(ds2[var]
                                              .sel(time=slice(ds1.time.values[-1], ds2.time.values[-1]))
                                              .isel(time=slice(1, None))) # this line prevents redundant timestamps
                         all_ds[var] = xr.concat(
                                         [ds1[var], tx_data_no_overlap], dim='time'
                                     ).sortby('time')
-
-                        # we now remove the negative step in accumulated precipitation
-                        # that appears at the transition between raw and transmitted data
-                        neg_diff = all_ds[var].diff(dim='time')
-                        neg_diff = neg_diff.where(neg_diff<0, other=0)
-                        all_ds[var] = all_ds[var] - neg_diff.cumsum()
-
         else:
             logger.info(f'Mismatched station names {n1}, {n2}')
             exit()

--- a/src/pypromice/pipeline/join_l2.py
+++ b/src/pypromice/pipeline/join_l2.py
@@ -67,7 +67,7 @@ def join_l2(file1,file2,outpath,variables,metadata) -> xr.Dataset:
             all_ds = ds1.combine_first(ds2)
 
             # Re-calculate corrected precipitation
-            for var in ['precip_u_cor', 'precip_l_cor']:
+            for var in ['precip_u', 'precip_l']:
                 if hasattr(all_ds, var):
                     if all_ds[var].notnull().any():
                         # combine_first works terrible for accumulated values

--- a/src/pypromice/pipeline/join_l3.py
+++ b/src/pypromice/pipeline/join_l3.py
@@ -495,20 +495,6 @@ def join_l3(config_folder, site, folder_l3, folder_gcnet, outpath, variables, me
                         ),
                     )
 
-            # adjusting accumulated precipitation when merging
-            for var in ['precip_u_cor', 'precip_l_cor']:
-                if hasattr(l3_merged, var):
-                    if l3_merged[var].notnull().any() and l3[var].notnull().any():
-                        t0 = l3_merged[var].to_series().first_valid_index()
-                        l3_merged[var] = l3_merged[var] \
-                            - l3_merged[var].sel(time=t0) + l3[var].sel(time=t0, method ='nearest')
-
-                        # we now remove the negative step in accumulated precipitation
-                        # that appears at the transition between raw and transmitted data
-                        neg_diff = l3_merged[var].diff(dim='time')
-                        neg_diff = neg_diff.where(neg_diff<0, other=0)
-                        l3_merged[var] = l3_merged[var] - neg_diff.cumsum()
-
             # saves attributes
             attrs = l3_merged.attrs
             # merging by time block

--- a/src/pypromice/pipeline/resample.py
+++ b/src/pypromice/pipeline/resample.py
@@ -49,13 +49,12 @@ def resample_dataset(ds_h, t):
     # Resample the DataFrame
     df_resampled = df_h.resample(t).mean()
 
-    # exception for precip_u and precip_l which are accumulated with some reset
-    # we therefore take the positive increments in the higher resolution data (like 10 min)
-    # and sum them into the aggregated data (hourly/daily/monthly).
-    # This makes the assumption of 0 precipitation during data gaps.
+    # exception for precip_u and precip_l which are semi-accumulated with some resets
+    # Taking the max value within the resampled time step will preserve the
+    #  general shape of the curve
     for var in ['precip_u', 'precip_l']:
         if var in df_h.columns:
-            df_resampled[var] = df_h[var].diff().clip(lower=0).resample(t).sum()
+            df_resampled[var] = df_h[var].resample(t).max()
 
     # exception for rainfall which should be summed when aggregated into
     # hourly/daily/monthly values. This ignores missing data.


### PR DESCRIPTION
`precip_u_cor` and `precip_l_cor` do not exist anymore

+ better resampling of `precip_u` and `precip_l`
+ bloc merging of these variables at level 2
+ removing special case for `precip_cor` in `join_l3.py`
+ no need for bloc merging of `precip` in join_l3 because it should not be outputted there