### PR TITLE
Bug fix/fixing z boom best

### DIFF
--- a/src/pypromice/core/variables/station_boom_height.py
+++ b/src/pypromice/core/variables/station_boom_height.py
@@ -25,25 +25,47 @@ def adjust(z_boom: xr.DataArray,
     return z_boom * ((air_temperature + T_0)/T_0)**0.5
 
 
-def adjust_and_include_uncorrected_values(z_boom: xr.DataArray,
-           air_temperature: xr.DataArray
+def include_uncorrected_values(
+    z_boom: xr.DataArray,
+    z_boom_cor: xr.DataArray,
+    air_temperature_1: xr.DataArray,
+    air_temperature_2: xr.DataArray = None,
+    t_rad: xr.DataArray = None,
+    T_0: float = 273.15,
 ) -> xr.DataArray:
-    """Adjust sonic ranger readings for sensitivity to air temperature,
-    and retain uncorrected values where air temperature measurements
-    are not available.
+    """
+    Adjust sonic ranger readings for sensitivity to air temperature and
+    retain uncorrected values where temperature measurements are unavailable.
 
     Parameters
     ----------
     z_boom : xr.DataArray
-        Station boom height from sonic ranger
-    air_temperature : xr.DataArray
-        Air temperature
+        Uncorrected station boom height from sonic ranger
+    z_boom_cor : xr.DataArray
+        Boom height corrected with air_temperature_1
+    air_temperature_1 : xr.DataArray
+        Primary air temperature
+    air_temperature_2 : xr.DataArray, optional
+        Secondary air temperature
+    t_rad : xr.DataArray, optional
+        Radiative temperature
+    T_0 : float, optional
+        Reference temperature in Kelvin (default 273.15)
 
     Returns
     -------
     xr.DataArray
-        Adjusted station boom height
+        Corrected boom height with fallback where needed
     """
-    return xr.where(air_temperature.notnull(),
-                    z_boom * ((air_temperature + T_0)/T_0)**0.5,
-                    z_boom)
+    if air_temperature_2 is None:
+        air_temperature_2 = xr.full_like(z_boom, np.nan)
+    if t_rad is None:
+        t_rad = xr.full_like(z_boom, np.nan)
+    else:
+        t_rad = t_rad.clip(max=0)
+
+    z_boom_cor_w_t_rad = z_boom * ((t_rad + T_0) / T_0) ** 0.5
+    z_boom_cor_w_ta2 = z_boom * ((air_temperature_2 + T_0) / T_0) ** 0.5
+    z_boom_ta2_t_rad = xr.where(air_temperature_2.notnull(), z_boom_cor_w_ta2, z_boom_cor_w_t_rad)
+
+    return xr.where(air_temperature_1.notnull(), z_boom_cor, z_boom_ta2_t_rad)

--- a/src/pypromice/pipeline/L2toL3.py
+++ b/src/pypromice/pipeline/L2toL3.py
@@ -216,8 +216,8 @@ def process_surface_height(ds, data_adjustments_dir, station_config={}):
             z_boom_best_l = station_boom_height.include_uncorrected_values(
                                         ds["z_boom_l"],
                                         ds["z_boom_cor_l"],
-                                        ds["t_u"],
-                                        ds["t_l"] if "t_l" in ds.data_vars else None,
+                                        ds["t_l"],
+                                        ds["t_u"] if "t_u" in ds.data_vars else None,
                                         ds["t_rad"] if "t_rad" in ds.data_vars else None)
 
             # need a combine first because KAN_U switches from having a z_stake_best

--- a/src/pypromice/resources/variables.csv
+++ b/src/pypromice/resources/variables.csv
@@ -34,13 +34,13 @@ dlhf_l,surface_downward_latent_heat_flux,Latent heat flux (lower boom),W m-2,mod
 dshf_u,surface_downward_sensible_heat_flux,Sensible heat flux (upper boom),W m-2,modelResult,time,FALSE,L3 or later,,,,all,0,0,1,4
 dshf_l,surface_downward_sensible_heat_flux,Sensible heat flux (lower boom),W m-2,modelResult,time,FALSE,L3 or later,,,,two-boom,0,0,1,4
 z_boom_u,distance_to_surface_from_boom,Upper boom height,m,physicalMeasurement,time,TRUE,,0.3,10,z_boom_cor_u,all,1,1,1,4
-z_boom_cor_u,distance_to_surface_from_boom_corrected,Upper boom height - corrected,m,modelResult,time,TRUE,,0.3,10,"",all,1,1,1,4
+z_boom_cor_u,distance_to_surface_from_boom_corrected,Upper boom height - corrected,m,modelResult,time,TRUE,,0.3,10,z_boom_u,all,1,1,1,4
 z_boom_q_u,distance_to_surface_from_boom_quality,Upper boom height (quality),-,qualityInformation,time,TRUE,L0 or L2,,,,all,1,1,0,4
 z_boom_l,distance_to_surface_from_boom,Lower boom height,m,physicalMeasurement,time,TRUE,,0.3,5,z_boom_cor_l,two-boom,1,1,1,4
-z_boom_cor_l,distance_to_surface_from_boom_corrected,Lower boom height - corrected,m,modelResult,time,TRUE,,0.3,5,"",two-boom,1,1,1,4
+z_boom_cor_l,distance_to_surface_from_boom_corrected,Lower boom height - corrected,m,modelResult,time,TRUE,,0.3,5,z_boom_l,two-boom,1,1,1,4
 z_boom_q_l,distance_to_surface_from_boom_quality,Lower boom height (quality),-,qualityInformation,time,TRUE,L0 or L2,,,,two-boom,1,1,0,4
 z_stake,distance_to_surface_from_stake_assembly,Stake height,m,physicalMeasurement,time,TRUE,,0.3,8,z_stake_cor,one-boom,1,1,1,4
-z_stake_cor,distance_to_surface_from_stake_assembly_corrected,Stake height - corrected,m,physicalMeasurement,time,TRUE,,0.3,8,,one-boom,1,1,1,4
+z_stake_cor,distance_to_surface_from_stake_assembly_corrected,Stake height - corrected,m,physicalMeasurement,time,TRUE,,0.3,8,z_stake,one-boom,1,1,1,4
 z_stake_q,distance_to_surface_from_stake_assembly_quality,Stake height (quality),-,qualityInformation,time,TRUE,L0 or L2,,,,one-boom,1,1,0,4
 z_pt,depth_of_pressure_transducer_in_ice,Depth of pressure transducer in ice,m,physicalMeasurement,time,FALSE,,0,30,z_pt_cor,one-boom,1,1,1,4
 z_pt_cor,depth_of_pressure_transducer_in_ice_corrected,Depth of pressure transducer in ice - corrected,m,modelResult,time,FALSE,L2 or later,0,30,,one-boom,0,1,1,4


### PR DESCRIPTION

In the previous implementation `z_boom_best` was calculated with `adjust_and_include_uncorrected_values` which recalculated its own version of corrected `z_boom_cor`, meaning that all "adjustment" filters applied on the official `z_boom_cor` outside of the function was not visible in `z_boom_best`. So this PR does:

- replaced `adjust_and_include_uncorrected_values`  by `include_uncorrected_values` which just combines uncorrected values with the QCed `z_boom_cor`
- `include_uncorrected_values` tries to use `t_l` and `t_rad` if available for the correction
- set co-dependency of `z_*` and `z_*_cor` so that filters on `z_*_cor` also remove the corresponding data to `z_*`
- added a custom filter to remove cases where a SR50 is failing and the corresponding value falls back on the other SR50 (https://github.com/GEUS-Glaciology-and-Climate/PROMICE-AWS-data-issues/issues/3)