### PR TITLE
Feature/switch back to older station when new one fails

### DIFF
--- a/src/pypromice/pipeline/L0toL1.py
+++ b/src/pypromice/pipeline/L0toL1.py
@@ -12,9 +12,9 @@ logger = logging.getLogger(__name__)
 
 from pypromice.core.variables.pressure_transducer_depth import correct_and_calculate_depth
 from pypromice.core.qc.value_clipping import clip_values
-from pypromice.core.variables import (wind, 
-                                      air_temperature, 
-                                      gps, 
+from pypromice.core.variables import (wind,
+                                      air_temperature,
+                                      gps,
                                       radiation,
                                       station_boom_height,
                                       station_pose,
@@ -125,6 +125,10 @@ def toL1(L0: xr.DataArray,
         logger.info(f'Wind speed correction applied to wspd_i based on factor of {ds.attrs["wind_i_coef"]}')
         ds['wspd_i'] = wind.correct_wind_speed(ds['wspd_i'],
                                                ds.attrs['wind_i_coef'])
+
+    if hasattr(ds, 'FRE_pressure_decoding'):
+        logger.info('Special decoding of air pressure')
+        ds['p_u'] = (ds['p_u']+1000)*0.2 + 600
 
     # Handle cases where the bedrock attribute is incorrectly set
     if not 'bedrock' in ds.attrs:

--- a/src/pypromice/pipeline/L2toL3.py
+++ b/src/pypromice/pipeline/L2toL3.py
@@ -295,7 +295,9 @@ def process_surface_height(ds, data_adjustments_dir, station_config={}):
         z_ice_surf.loc[gaps_to_fill] = df_filled.loc[gaps_to_fill]
 
         # bringing the variable into the dataset
-        ds['z_ice_surf'] = ('time', z_ice_surf.values)
+        ds['z_ice_surf'] = post_processing_z_ice_surf(ds.z_ice_surf,
+                                              ds.z_surf_combined,
+                                              ds.z_surf_2_adj)
 
         ds['z_surf_combined'] = np.maximum(ds['z_surf_combined'], ds['z_ice_surf'])
         ds['snow_height'] = np.maximum(0, ds['z_surf_combined'] - ds['z_ice_surf'])
@@ -942,6 +944,65 @@ def get_thermistor_depth(df_in, site, station_config):
 
     return df_in[depth_cols_name + ['t_i_10m']]
 
+
+def post_processing_z_ice_surf(z_ice_surf, z_surf_combined, z_surf_2_adj):
+    # here we make sure that the periods where both z_stake and z_pt are
+    # missing are also missing in z_ice_surf
+    msk = z_ice_surf.notnull() | z_surf_2_adj.notnull()
+
+    # Calculate rolling minimum for ice surface height and snow height
+    ts_interpolated = np.minimum(
+        xr.where(z_ice_surf.notnull(),  z_ice_surf, z_surf_combined),
+        z_surf_combined).to_series().resample('h').interpolate(limit=72)
+
+    if len(ts_interpolated)>24*7:
+        # Apply the rolling window with median calculation
+        z_ice_surf = (ts_interpolated
+                      .rolling('14D', center=True, min_periods=1)
+                      .median())
+        # Overprint the first and last 7 days with interpolated values
+        # because of edge effect of rolling windows
+        z_ice_surf.iloc[:24*7] = (ts_interpolated.iloc[:24*7]
+                                  .rolling('1D', center=True, min_periods=1)
+                                  .median().values)
+        z_ice_surf.iloc[-24*7:] = (ts_interpolated.iloc[-24*7:]
+                                   .rolling('1D', center=True, min_periods=1)
+                                   .median().values)
+    else:
+        z_ice_surf = (ts_interpolated
+                                   .rolling('1D', center=True, min_periods=1)
+                                   .median())
+
+    z_ice_surf = z_ice_surf.loc[z_surf_combined.time]
+    # here we make sure that the periods where both z_stake and z_pt are
+    # missing are also missing in z_ice_surf
+    z_ice_surf = z_ice_surf.where(msk)
+
+    # taking running minimum to get ice
+    z_ice_surf = z_ice_surf.cummin()
+
+    # filling gaps only if they are less than a year long and if values on both
+    # sides are less than 0.01 m appart
+
+    # Forward and backward fill to identify bounds of gaps
+    df_filled = z_ice_surf.fillna(method='ffill').fillna(method='bfill')
+
+    # Identify gaps and their start and end dates
+    gaps = pd.DataFrame(index=z_ice_surf[z_ice_surf.isna()].index)
+    gaps['prev_value'] = df_filled.shift(1)
+    gaps['next_value'] = df_filled.shift(-1)
+    gaps['gap_start'] = gaps.index.to_series().shift(1)
+    gaps['gap_end'] = gaps.index.to_series().shift(-1)
+    gaps['gap_duration'] = (gaps['gap_end'] - gaps['gap_start']).dt.days
+    gaps['value_diff'] = (gaps['next_value'] - gaps['prev_value']).abs()
+
+    # Determine which gaps to fill
+    mask = (gaps['gap_duration'] < 365) & (gaps['value_diff'] < 0.01)
+    gaps_to_fill = gaps[mask].index
+
+    # Fill gaps in the original Series
+    z_ice_surf.loc[gaps_to_fill] = df_filled.loc[gaps_to_fill]
+    return z_ice_surf
 
 def interpolate_temperature(dates, depth_cor, temp, depth=10, min_diff_to_depth=2,
     kind="quadratic"):

--- a/src/pypromice/pipeline/L2toL3.py
+++ b/src/pypromice/pipeline/L2toL3.py
@@ -237,64 +237,7 @@ def process_surface_height(ds, data_adjustments_dir, station_config={}):
 
 
     if ds.attrs['site_type'] == 'ablation':
-        # Calculate rolling minimum for ice surface height and snow height
-        ts_interpolated = np.minimum(
-            xr.where(ds.z_ice_surf.notnull(),
-                     ds.z_ice_surf,ds.z_surf_combined),
-            ds.z_surf_combined).to_series().resample('h').interpolate(limit=72)
-
-        if len(ts_interpolated)>24*7:
-            # Apply the rolling window with median calculation
-            z_ice_surf = (ts_interpolated
-                          .rolling('14D', center=True, min_periods=1)
-                          .median())
-            # Overprint the first and last 7 days with interpolated values
-            # because of edge effect of rolling windows
-            z_ice_surf.iloc[:24*7] = (ts_interpolated.iloc[:24*7]
-                                      .rolling('1D', center=True, min_periods=1)
-                                      .median().values)
-            z_ice_surf.iloc[-24*7:] = (ts_interpolated.iloc[-24*7:]
-                                       .rolling('1D', center=True, min_periods=1)
-                                       .median().values)
-        else:
-            z_ice_surf = (ts_interpolated
-                                       .rolling('1D', center=True, min_periods=1)
-                                       .median())
-
-        z_ice_surf = z_ice_surf.reindex(ds.time,
-                                        method=None).interpolate(method='time')
-
-        # here we make sure that the periods where both z_stake_best and z_pt are
-        # missing are also missing in z_ice_surf
-        msk = ds['z_ice_surf'].notnull() | ds['z_surf_2_adj'].notnull()
-        z_ice_surf = z_ice_surf.where(msk)
-
-        # taking running minimum to get ice
-        z_ice_surf = z_ice_surf.cummin()
-
-        # filling gaps only if they are less than a year long and if values on both
-        # sides are less than 0.01 m appart
-
-        # Forward and backward fill to identify bounds of gaps
-        df_filled = z_ice_surf.ffill().bfill()
-
-        # Identify gaps and their start and end dates
-        gaps = pd.DataFrame(index=z_ice_surf[z_ice_surf.isna()].index)
-        gaps['prev_value'] = df_filled.shift(1)
-        gaps['next_value'] = df_filled.shift(-1)
-        gaps['gap_start'] = gaps.index.to_series().shift(1)
-        gaps['gap_end'] = gaps.index.to_series().shift(-1)
-        gaps['gap_duration'] = (gaps['gap_end'] - gaps['gap_start']).dt.days
-        gaps['value_diff'] = (gaps['next_value'] - gaps['prev_value']).abs()
-
-        # Determine which gaps to fill
-        mask = (gaps['gap_duration'] < 365) & (gaps['value_diff'] < 0.01)
-        gaps_to_fill = gaps[mask].index
-
-        # Fill gaps in the original Series
-        z_ice_surf.loc[gaps_to_fill] = df_filled.loc[gaps_to_fill]
-
-        # bringing the variable into the dataset
+        # post processing z_ice_surf
         ds['z_ice_surf'] = post_processing_z_ice_surf(ds.z_ice_surf,
                                               ds.z_surf_combined,
                                               ds.z_surf_2_adj)
@@ -946,13 +889,13 @@ def get_thermistor_depth(df_in, site, station_config):
 
 
 def post_processing_z_ice_surf(z_ice_surf, z_surf_combined, z_surf_2_adj):
-    # here we make sure that the periods where both z_stake and z_pt are
-    # missing are also missing in z_ice_surf
+    # saving times where both z_stake and z_pt are missing
+    # over these periods, z_ice_surf will not be gap-filled
     msk = z_ice_surf.notnull() | z_surf_2_adj.notnull()
 
     # Calculate rolling minimum for ice surface height and snow height
     ts_interpolated = np.minimum(
-        xr.where(z_ice_surf.notnull(),  z_ice_surf, z_surf_combined),
+        xr.where(z_ice_surf.notnull(), z_ice_surf, z_surf_combined),
         z_surf_combined).to_series().resample('h').interpolate(limit=72)
 
     if len(ts_interpolated)>24*7:
@@ -974,8 +917,8 @@ def post_processing_z_ice_surf(z_ice_surf, z_surf_combined, z_surf_2_adj):
                                    .median())
 
     z_ice_surf = z_ice_surf.loc[z_surf_combined.time]
-    # here we make sure that the periods where both z_stake and z_pt are
-    # missing are also missing in z_ice_surf
+
+    # removing from z_ice_surf the periods where both z_stake_best and z_pt are missing
     z_ice_surf = z_ice_surf.where(msk)
 
     # taking running minimum to get ice
@@ -985,7 +928,7 @@ def post_processing_z_ice_surf(z_ice_surf, z_surf_combined, z_surf_2_adj):
     # sides are less than 0.01 m appart
 
     # Forward and backward fill to identify bounds of gaps
-    df_filled = z_ice_surf.fillna(method='ffill').fillna(method='bfill')
+    df_filled = z_ice_surf.ffill().bfill()
 
     # Identify gaps and their start and end dates
     gaps = pd.DataFrame(index=z_ice_surf[z_ice_surf.isna()].index)


### PR DESCRIPTION
This pull request supersedes [PR #323](https://github.com/GEUS-Glaciology-and-Climate/pypromice/pull/323) and [PR #328](https://github.com/GEUS-Glaciology-and-Climate/pypromice/pull/328), which were closed because on an obsolete version of pypromice.

This PR fixes #321: [Current way of merging stations into sites ignores useful data at KPC_U, KPC_L, CEN and SWC](https://github.com/GEUS-Glaciology-and-Climate/pypromice/issues/321) 