### PR TITLE
Build dependencies explicitly defined

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "numpy~=1.23",
     "pandas>=1.5.0",
     "xarray>=2022.6.0",
+    "attrs",
     "toml",
     "scipy>=1.9.0",
     "Bottleneck",


### PR DESCRIPTION
Dependencies now explicitly defined in pyproject.toml file, in order for `pip install pypromice[all]` to work