### PR TITLE
Enhanced payload decoding and format support

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2025, GEUS Glaciology and Climate'
 author = 'GEUS Glaciology and Climate'
 
 # The full version, including alpha/beta/rc tags
-release = '1.12.1'
+release = '1.12.2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pypromice"
-version = "1.10.0"
+version = "1.10.2"
 description = "PROMICE/GC-Net toolbox for processing data from automatic weather stations"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pypromice"
-version = "1.10.2"
+version = "1.10.0"
 description = "PROMICE/GC-Net toolbox for processing data from automatic weather stations"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pypromice"
-version = "1.12.1"
+version = "1.12.2"
 description = "PROMICE/GC-Net toolbox for processing data from automatic weather stations"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ create_bufr_files = "pypromice.io.bufr.create_bufr_files:main"
 bufr_to_csv = "pypromice.io.bufr.bufr_to_csv:main"
 get_l0tx = "pypromice.tx.get_l0tx:main"
 get_msg = "pypromice.tx.get_msg:get_msg"
+decode_payload = "pypromice.tx.payload_decoder:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/pypromice/resources/payload_formats.csv
+++ b/src/pypromice/resources/payload_formats.csv
@@ -68,6 +68,8 @@ type,expected_values,format,description,flags,notes
 90,48,tfffffffffffffffffffffffffffffffffgnefffffffffff,THE GC-NET VERSION!,,GC-NET stations
 95,46,tfffffffffffffffffffffffffffffffgnefffffffffff,THE GC-NET VERSION!,,GC-NET stations
 115,47,tfffffffffffffffffffffffffffffffffgneffffffffff,PREMAS version,,PREMAS stations
+200,30,tffffcwlwwwllwwwllffgneffffbfb,60-min-data-table,,SR_DYE2 Finapp_PWR_ST
+201,26,tccfwbffwcffffffbfffwfbffw,Monthly diagnostics data,,SR_DYE2 Finapp_PWR_ST ONLY TX once a month, on the first of every month at 00:10
 220,29,tfffffffffffffffffffffffnefff,ZAMG Freya 2015 summer message,,ZAMG Freya aws
 221,0,,,,ZAMG Freya aws
 222,29,tfffffffffffffffffffffffnefff,ZAMG Freya 2015 winter message,,ZAMG Freya aws

--- a/src/pypromice/resources/payload_formats.csv
+++ b/src/pypromice/resources/payload_formats.csv
@@ -19,7 +19,7 @@ type,expected_values,format,description,flags,notes
 22,41,tfffffffffffffffffffffffffffffffffgneffff,GlacioBasis 2009 Top 6-h winter message,,GlacioBasis 2009 Top
 23,0,,unused,,GlacioBasis 2009 Top
 24,22,tfffffffffffffffffffff,GlacioBasis 2009 Top diagnostic message,,GlacioBasis 2009 Top
-25,13,tffffffffffff,Sermilik 2009 1-h summer message,,Sermilik 2010 (corresponds to BinaryTxFormatRevision = 5 in the datalogger program)
+25,13,tffffcwlwwwllwwwllffgneffffbfb,Sermilik 2009 1-h summer message,,Sermilik 2010 (corresponds to BinaryTxFormatRevision = 5 in the datalogger program)
 26,39,tfffffffffffffffffffffffffgneffffffffff,Sermilik 2009 1-h summer message (+ instant.),,Sermilik 2010 (corresponds to BinaryTxFormatRevision = 5 in the datalogger program)
 27,13,tffffffffffff,Sermilik 2009 6-h winter message,,Sermilik 2010 (corresponds to BinaryTxFormatRevision = 5 in the datalogger program)
 28,39,tfffffffffffffffffffffffffgneffffffffff,Sermilik 2009 6-h winter message (+ instant.),,Sermilik 2010 (corresponds to BinaryTxFormatRevision = 5 in the datalogger program)
@@ -36,7 +36,7 @@ type,expected_values,format,description,flags,notes
 40,14,tfffffffffffff,GlacioBasis+DMI 2018 summer message,,GlacioBasis+DMI 2018; there is 2 more than promice 2015 (T_IR; IR_T)
 41,39,tffffffffffffffffffffffffffgnefffffffff,GlacioBasis+DMI 2018 summer message (+ instant.),,GlacioBasis+DMI 2018; there is 2 more than promice 2015 (T_IR; IR_T)
 42,14,tfffffffffffff,GlacioBasis+DMI 2018 winter message,,GlacioBasis+DMI 2018; there is 2 more than promice 2015 (T_IR; IR_T)
-43,39,tffffffffffffffffffffffffffgnefffffffff,GlacioBasis+DMI 2018 winter message (+ instant.),,GlacioBasis+DMI 2018; there is 2 more than promice 2015 (T_IR; IR_T)
+43,39,tccfwbffwcffffffbfffwfbffw,GlacioBasis+DMI 2018 winter message (+ instant.),,GlacioBasis+DMI 2018; there is 2 more than promice 2015 (T_IR; IR_T)
 44,6,tfffff,GlacioBasis+DMI 2018 diagnostic message,,GlacioBasis+DMI 2018; there is 2 more than promice 2015 (T_IR; IR_T)
 48,0,,,,placeholders for illegal format numbers (reserved for ascii decimal numbers; codes 48 for '0' to 57 for '9')
 49,0,,,,placeholders for illegal format numbers (reserved for ascii decimal numbers; codes 48 for '0' to 57 for '9')

--- a/src/pypromice/resources/payload_formats.csv
+++ b/src/pypromice/resources/payload_formats.csv
@@ -19,7 +19,7 @@ type,expected_values,format,description,flags,notes
 22,41,tfffffffffffffffffffffffffffffffffgneffff,GlacioBasis 2009 Top 6-h winter message,,GlacioBasis 2009 Top
 23,0,,unused,,GlacioBasis 2009 Top
 24,22,tfffffffffffffffffffff,GlacioBasis 2009 Top diagnostic message,,GlacioBasis 2009 Top
-25,13,tffffcwlwwwllwwwllffgneffffbfb,Sermilik 2009 1-h summer message,,Sermilik 2010 (corresponds to BinaryTxFormatRevision = 5 in the datalogger program)
+25,13,tffffffffffff,Sermilik 2009 1-h summer message,,Sermilik 2010 (corresponds to BinaryTxFormatRevision = 5 in the datalogger program)
 26,39,tfffffffffffffffffffffffffgneffffffffff,Sermilik 2009 1-h summer message (+ instant.),,Sermilik 2010 (corresponds to BinaryTxFormatRevision = 5 in the datalogger program)
 27,13,tffffffffffff,Sermilik 2009 6-h winter message,,Sermilik 2010 (corresponds to BinaryTxFormatRevision = 5 in the datalogger program)
 28,39,tfffffffffffffffffffffffffgneffffffffff,Sermilik 2009 6-h winter message (+ instant.),,Sermilik 2010 (corresponds to BinaryTxFormatRevision = 5 in the datalogger program)
@@ -36,7 +36,7 @@ type,expected_values,format,description,flags,notes
 40,14,tfffffffffffff,GlacioBasis+DMI 2018 summer message,,GlacioBasis+DMI 2018; there is 2 more than promice 2015 (T_IR; IR_T)
 41,39,tffffffffffffffffffffffffffgnefffffffff,GlacioBasis+DMI 2018 summer message (+ instant.),,GlacioBasis+DMI 2018; there is 2 more than promice 2015 (T_IR; IR_T)
 42,14,tfffffffffffff,GlacioBasis+DMI 2018 winter message,,GlacioBasis+DMI 2018; there is 2 more than promice 2015 (T_IR; IR_T)
-43,39,tccfwbffwcffffffbfffwfbffw,GlacioBasis+DMI 2018 winter message (+ instant.),,GlacioBasis+DMI 2018; there is 2 more than promice 2015 (T_IR; IR_T)
+43,39,tffffffffffffffffffffffffffgnefffffffff,GlacioBasis+DMI 2018 winter message (+ instant.),,GlacioBasis+DMI 2018; there is 2 more than promice 2015 (T_IR; IR_T)
 44,6,tfffff,GlacioBasis+DMI 2018 diagnostic message,,GlacioBasis+DMI 2018; there is 2 more than promice 2015 (T_IR; IR_T)
 48,0,,,,placeholders for illegal format numbers (reserved for ascii decimal numbers; codes 48 for '0' to 57 for '9')
 49,0,,,,placeholders for illegal format numbers (reserved for ascii decimal numbers; codes 48 for '0' to 57 for '9')

--- a/src/pypromice/resources/payload_formats.csv
+++ b/src/pypromice/resources/payload_formats.csv
@@ -69,7 +69,8 @@ type,expected_values,format,description,flags,notes
 95,46,tfffffffffffffffffffffffffffffffgnefffffffffff,THE GC-NET VERSION!,,GC-NET stations
 115,47,tfffffffffffffffffffffffffffffffffgneffffffffff,PREMAS version,,PREMAS stations
 200,30,tffffcwlwwwllwwwllffgneffffbfb,60-min-data-table,,SR_DYE2 Finapp_PWR_ST
-201,26,tccfwbffwcffffffbfffwfbffw,Monthly diagnostics data,,SR_DYE2 Finapp_PWR_ST ONLY TX once a month, on the first of every month at 00:10
+201,26,tccfwbffwcffffffbfffwfbffw,Monthly diagnostics data,,SR_DYE2 Finapp_PWR_ST ONLY TX once a month on the first of every month at 00:10
+202,13,tffffffffffff,Cave Temp hourly transmissions,,Cave Temp
 220,29,tfffffffffffffffffffffffnefff,ZAMG Freya 2015 summer message,,ZAMG Freya aws
 221,0,,,,ZAMG Freya aws
 222,29,tfffffffffffffffffffffffnefff,ZAMG Freya 2015 winter message,,ZAMG Freya aws

--- a/src/pypromice/resources/payload_types.csv
+++ b/src/pypromice/resources/payload_types.csv
@@ -5,3 +5,6 @@ t,4,%Y-%m-%d %H:%M:%S,,,,timestamp as seconds since 1990-01-01 00:00:00 +0000 en
 g,4,100,,,,GPS time encoded as GLI4
 n,4,100000,,,,GPS latitude encoded as GLI4
 e,4,100000,,,,GPS latitude encoded as GLI4
+c,3,1,,16777216,,3 byte unsigned int (color)
+w,2,1,,65536,,"Word, 2 byte unsigned int"
+b,1,1,,"",,byte

--- a/src/pypromice/tx/payload_decoder.py
+++ b/src/pypromice/tx/payload_decoder.py
@@ -10,23 +10,23 @@ Additionally, logging is used for debug information throughout the decoding
 process.
 """
 import logging
-import numpy as np
 from datetime import datetime
 from pathlib import Path
 
+import numpy as np
+from pypromice.resources import DEFAULT_PAYLOAD_FORMATS_PATH
+
 __all__ = [
+    "decode_payload",
     "DecodeError",
-    "determine_payload_format",
-    "decode"
 ]
+
 
 logger = logging.getLogger(__name__)
 
 CR_BASIC_EPOCH_OFFSET = datetime(1990, 1, 1, 0, 0, 0, 0).timestamp()
 
-
 class DecodeError(Exception):
-    """Decoding error exception object"""
 
     def __init__(
         self,
@@ -64,18 +64,7 @@ class DecodeError(Exception):
 
 
 def parse_gfp2(buffer: bytes) -> float:
-    """Two-byte floating point decoder
-
-    Parameters
-    ----------
-    buffer : bytes
-        List of two values
-
-    Returns
-    -------
-    float
-        Decoded value
-    """
+    """Two-byte floating point decoder"""
     if len(buffer) < 2:
         raise ValueError("Buffer too short for gfp2 decoding")
 
@@ -103,7 +92,7 @@ def parse_gli4(buffer: bytes) -> int:
     ----------
     buffer : bytes
         List of four values
-        
+
     Returns
     -------
     float
@@ -116,21 +105,6 @@ def parse_gli4(buffer: bytes) -> int:
 
 
 def determine_payload_format(payload: bytes, payload_formats_path: Path) -> str:
-    """Determine payload format from lookup table, based on the first byte in
-    the payload
-
-    Parameters
-    ----------
-    payload : bytes
-        Payload message
-    payload_formats_path : Path
-        File path to payload formats lookup table
-
-    Returns
-    -------
-    bin_format : str
-        Binary format of payload
-    """
     payload_formats = pd.read_csv(payload_formats_path, index_col=0)
     payload_formats = payload_formats[payload_formats["flags"].values != "don’t use"]
 
@@ -152,21 +126,19 @@ def determine_payload_format(payload: bytes, payload_formats_path: Path) -> str:
     return bin_format
 
 
+def decode_payload(
+    payload: bytes,
+    payload_format: str | None = None,
+    payload_formats_path: Path | None = None,
+) -> list:
+    if payload_format is None:
+        payload_format = determine_payload_format(payload, payload_formats_path)
+    dataline = decode(payload_format, payload)
+
+    return dataline
+
+
 def decode(bin_format: str, payload: bytes) -> list:
-    """Decode a payload, based on a pre-defined format identifier
-
-    Parameters
-    ----------
-    bin_format : str
-        Binary payload format identifier
-    payload : bytes
-        Payload message
-
-    Returns
-    -------
-    dataline : list
-        Decoded payload
-    """
     payload_length = len(payload)
     logger.info(f"Decoding payload with format: {bin_format!r}. Payload length: {payload_length}")
     logger.debug(f"Payload: {payload!r}")
@@ -181,7 +153,6 @@ def decode(bin_format: str, payload: bytes) -> list:
             )
 
             if type_letter == "f":
-                # Encoded as 2 bytes base-10 floating point (GFP2)
                 nan_values = (8191,)
                 inf_values = (8190,)
                 neg_inf_values = -8190, -8191
@@ -198,9 +169,33 @@ def decode(bin_format: str, payload: bytes) -> list:
                 else:
                     dataline.append(value)
                 indx += 2
+            
+            elif type_letter == "b":
+                # Unsigned integer encoded as a single byte
+                if indx + 1 > payload_length:
+                    raise Exception("Payload too short for 'b' (1-byte unsigned integer)")
+                value = payload[indx]
+                dataline.append(value)
+                indx += 1
 
+            elif type_letter == "w":
+                # Unsigned integer encoded as two bytes (big-endian)
+                if indx + 2 > payload_length:
+                    raise Exception("Payload too short for 'w' (2-byte unsigned integer)")
+                value = int.from_bytes(payload[indx:indx + 2], byteorder="big", signed=False)
+                dataline.append(value)
+                indx += 2
+                
+            elif type_letter == "c":
+                # Unsigned integer encoded as two bytes (big-endian)
+                if indx + 3 > payload_length:
+                    raise Exception("Payload too short for 'c' (3-byte unsigned integer)")
+                value = int.from_bytes(payload[indx:indx + 3], byteorder="big", signed=False)
+                dataline.append(value)
+                indx += 3
+            
             elif type_letter == "l":
-                # Encoded as 4 bytes two complement integer (GLI4) - note the mac nan value is not a max value
+                # Encoded as a 4 byte two complement integer
 
                 value = parse_gli4(payload[indx:])
 
@@ -214,14 +209,13 @@ def decode(bin_format: str, payload: bytes) -> list:
                 indx += 4
 
             elif type_letter == "t":
-                # timestamp as seconds since 1990-01-01 00:00:00 +0000 encoded as GLI4
                 value = parse_gli4(payload[indx:])
                 time = datetime.fromtimestamp(CR_BASIC_EPOCH_OFFSET + value)
                 dataline.append(time)
                 indx += 4
 
+            # GPS time or coordinate encoding
             elif type_letter in ("g", "n", "e"):
-                # GPS time or coordinate encoding
                 nan_values_fp2 = (8191,)
                 # Check if byte is a 2-bit NAN. This occurs when the GPS data is not
                 # available and the logger sends a 2-bytes NAN instead of a 4-bytes value
@@ -291,9 +285,10 @@ if __name__ == "__main__":
         default="INFO",
     )
     parser.add_argument(
-        "--payload_formats_path",
+        "--payload_format_path",
         type=Path,
-        help="Path to payload formats .csv file",
+        help="Path to payload format .csv file",
+        default=DEFAULT_PAYLOAD_FORMATS_PATH,
     )
     parser.add_argument(
         "--drop_checksum_suffix",
@@ -313,6 +308,7 @@ if __name__ == "__main__":
         root_logger = logging.getLogger()
         root_logger.setLevel(getattr(logging, args.log_level))
 
+
     if isinstance(args.payload_file_path, Path):
         with open(args.payload_file_path, "rb") as payload_file:
             payload = payload_file.read()
@@ -323,12 +319,10 @@ if __name__ == "__main__":
     if args.drop_checksum_suffix:
         payload = payload[:-2]
 
-    if args.format is not None:
-        payload_format = args.format
-    else:
-        if args.payload_formats_path is None:
-            raise ValueError("Payload format path must be specified if decoding format is not specified")
-        payload_format = determine_payload_format(payload, args.payload_formats_path)
-    decoded = decode(payload_format, payload)
+    decoded = decode_payload(
+        payload,
+        payload_format=args.format,
+        payload_formats_path=args.payload_format_path,
+    )
 
     df = pd.DataFrame([decoded]).to_csv(sys.stdout, index=False, header=False)

--- a/src/pypromice/tx/payload_decoder.py
+++ b/src/pypromice/tx/payload_decoder.py
@@ -14,7 +14,6 @@ from datetime import datetime
 from pathlib import Path
 
 import numpy as np
-from pypromice.resources import DEFAULT_PAYLOAD_FORMATS_PATH
 
 __all__ = [
     "decode_payload",
@@ -132,6 +131,13 @@ def decode_payload(
     payload_formats_path: Path | None = None,
 ) -> list:
     if payload_format is None:
+        if payload_formats_path is None:
+            try:
+                from pypromice.resources import DEFAULT_PAYLOAD_FORMATS_PATH
+                payload_formats_path = DEFAULT_PAYLOAD_FORMATS_PATH
+            except ImportError:
+                raise Exception("Payload formats path not specified and not found in resources")
+
         payload_format = determine_payload_format(payload, payload_formats_path)
     dataline = decode(payload_format, payload)
 
@@ -288,7 +294,7 @@ if __name__ == "__main__":
         "--payload_format_path",
         type=Path,
         help="Path to payload format .csv file",
-        default=DEFAULT_PAYLOAD_FORMATS_PATH,
+        default=None,
     )
     parser.add_argument(
         "--drop_checksum_suffix",

--- a/src/pypromice/tx/payload_decoder.py
+++ b/src/pypromice/tx/payload_decoder.py
@@ -13,7 +13,6 @@ process.
 import glob
 import logging
 from datetime import datetime
-from multiprocessing.connection import default_family
 from pathlib import Path
 
 import numpy as np
@@ -31,6 +30,7 @@ CR_BASIC_EPOCH_OFFSET = datetime(1990, 1, 1, 0, 0, 0, 0).timestamp()
 
 
 class DecodeError(Exception):
+    """Decoding error exception object"""
 
     def __init__(
         self,
@@ -68,7 +68,18 @@ class DecodeError(Exception):
 
 
 def parse_gfp2(buffer: bytes) -> float:
-    """Two-byte floating point decoder"""
+    """Two-byte floating point decoder
+
+    Parameters
+    ----------
+    buffer : bytes
+        List of two values
+
+    Returns
+    -------
+    float
+        Decoded value
+    """
     if len(buffer) < 2:
         raise ValueError("Buffer too short for gfp2 decoding")
 
@@ -109,6 +120,21 @@ def parse_gli4(buffer: bytes) -> int:
 
 
 def determine_payload_format(payload: bytes, payload_formats_path: Path) -> str:
+    """Determine payload format from lookup table, based on the first byte in
+    the payload
+
+    Parameters
+    ----------
+    payload : bytes
+        Payload message
+    payload_formats_path : Path
+        File path to payload formats lookup table
+
+    Returns
+    -------
+    bin_format : str
+        Binary format of payload
+    """
     payload_formats = pd.read_csv(payload_formats_path, index_col=0)
     payload_formats = payload_formats[payload_formats["flags"].values != "don’t use"]
 
@@ -135,6 +161,25 @@ def decode_payload(
     payload_format: str | None = None,
     payload_formats_path: Path | None = None,
 ) -> list:
+    """Decode a payload, determining its binary format automatically unless
+    explicitly specified
+
+    Parameters
+    ----------
+    payload : bytes
+        Payload message
+    payload_format : str, optional
+        Explicit binary payload format identifier. If not given, it is
+        determined from `payload_formats_path`
+    payload_formats_path : Path, optional
+        File path to payload formats lookup table. Defaults to the
+        resources bundled with pypromice
+
+    Returns
+    -------
+    dataline : list
+        Decoded payload
+    """
     if payload_format is None:
         if payload_formats_path is None:
             try:
@@ -153,6 +198,20 @@ def decode_payload(
 
 
 def decode(bin_format: str, payload: bytes) -> list:
+    """Decode a payload, based on a pre-defined format identifier
+
+    Parameters
+    ----------
+    bin_format : str
+        Binary payload format identifier
+    payload : bytes
+        Payload message
+
+    Returns
+    -------
+    dataline : list
+        Decoded payload
+    """
     payload_length = len(payload)
     logger.info(
         f"Decoding payload with format: {bin_format!r}. Payload length: {payload_length}"
@@ -209,7 +268,7 @@ def decode(bin_format: str, payload: bytes) -> list:
                 indx += 2
 
             elif type_letter == "c":
-                # Unsigned integer encoded as two bytes (big-endian)
+                # Unsigned integer encoded as three bytes (big-endian)
                 if indx + 3 > payload_length:
                     raise Exception(
                         "Payload too short for 'c' (3-byte unsigned integer)"
@@ -298,7 +357,8 @@ def main():
         "-p",
         type=str,
         nargs="+",
-        help="Paths to payload files",
+        help="Paths to payload files. Supports glob patterns, for terminals "
+        "that don't expand them automatically",
         required=True,
     )
     parser.add_argument(
@@ -345,10 +405,14 @@ def main():
         root_logger = logging.getLogger()
         root_logger.setLevel(getattr(logging, args.log_level))
 
-    payload_paths = [
-        Path(p) for p_input in args.payload_file_paths for p in glob.glob(p_input)
-    ]
-    payload_paths = sorted(payload_paths, key=lambda p: p.as_posix())
+    payload_paths = []
+    for p_input in args.payload_file_paths:
+        matches = sorted(Path(p) for p in glob.glob(p_input))
+        if not matches:
+            raise FileNotFoundError(
+                f"No files found matching payload file path: {p_input!r}"
+            )
+        payload_paths.extend(matches)
 
     lines = []
     for payload_file_path in payload_paths:

--- a/src/pypromice/tx/payload_decoder.py
+++ b/src/pypromice/tx/payload_decoder.py
@@ -9,8 +9,11 @@ is implemented to handle errors that may occur during the decoding process.
 Additionally, logging is used for debug information throughout the decoding
 process.
 """
+
+import glob
 import logging
 from datetime import datetime
+from multiprocessing.connection import default_family
 from pathlib import Path
 
 import numpy as np
@@ -25,6 +28,7 @@ import pandas as pd
 logger = logging.getLogger(__name__)
 
 CR_BASIC_EPOCH_OFFSET = datetime(1990, 1, 1, 0, 0, 0, 0).timestamp()
+
 
 class DecodeError(Exception):
 
@@ -135,9 +139,12 @@ def decode_payload(
         if payload_formats_path is None:
             try:
                 from pypromice.resources import DEFAULT_PAYLOAD_FORMATS_PATH
+
                 payload_formats_path = DEFAULT_PAYLOAD_FORMATS_PATH
             except ImportError:
-                raise Exception("Payload formats path not specified and not found in resources")
+                raise Exception(
+                    "Payload formats path not specified and not found in resources"
+                )
 
         payload_format = determine_payload_format(payload, payload_formats_path)
     dataline = decode(payload_format, payload)
@@ -147,7 +154,9 @@ def decode_payload(
 
 def decode(bin_format: str, payload: bytes) -> list:
     payload_length = len(payload)
-    logger.info(f"Decoding payload with format: {bin_format!r}. Payload length: {payload_length}")
+    logger.info(
+        f"Decoding payload with format: {bin_format!r}. Payload length: {payload_length}"
+    )
     logger.debug(f"Payload: {payload.hex()!r}")
     # Note: bin_val is just len(bin_format)
     indx = 1  # The first byte is the payload format
@@ -176,11 +185,13 @@ def decode(bin_format: str, payload: bytes) -> list:
                 else:
                     dataline.append(value)
                 indx += 2
-            
+
             elif type_letter == "b":
                 # Unsigned integer encoded as a single byte
                 if indx + 1 > payload_length:
-                    raise Exception("Payload too short for 'b' (1-byte unsigned integer)")
+                    raise Exception(
+                        "Payload too short for 'b' (1-byte unsigned integer)"
+                    )
                 value = payload[indx]
                 dataline.append(value)
                 indx += 1
@@ -188,19 +199,27 @@ def decode(bin_format: str, payload: bytes) -> list:
             elif type_letter == "w":
                 # Unsigned integer encoded as two bytes (big-endian)
                 if indx + 2 > payload_length:
-                    raise Exception("Payload too short for 'w' (2-byte unsigned integer)")
-                value = int.from_bytes(payload[indx:indx + 2], byteorder="big", signed=False)
+                    raise Exception(
+                        "Payload too short for 'w' (2-byte unsigned integer)"
+                    )
+                value = int.from_bytes(
+                    payload[indx : indx + 2], byteorder="big", signed=False
+                )
                 dataline.append(value)
                 indx += 2
-                
+
             elif type_letter == "c":
                 # Unsigned integer encoded as two bytes (big-endian)
                 if indx + 3 > payload_length:
-                    raise Exception("Payload too short for 'c' (3-byte unsigned integer)")
-                value = int.from_bytes(payload[indx:indx + 3], byteorder="big", signed=False)
+                    raise Exception(
+                        "Payload too short for 'c' (3-byte unsigned integer)"
+                    )
+                value = int.from_bytes(
+                    payload[indx : indx + 3], byteorder="big", signed=False
+                )
                 dataline.append(value)
                 indx += 3
-            
+
             elif type_letter == "l":
                 # Encoded as a 4 byte two complement integer
 
@@ -271,18 +290,23 @@ def main():
     import pandas as pd
     from pathlib import Path
 
-    parser = argparse.ArgumentParser(description="Payload decoder tool for CRBasic logger")
+    parser = argparse.ArgumentParser(
+        description="Payload decoder tool for CRBasic logger"
+    )
     parser.add_argument(
-        "--payload_file_path",
+        "--payload_file_paths",
         "-p",
-        type=Path,
-        help="Path to payload file",
-        default=None,
+        type=str,
+        nargs="+",
+        help="Paths to payload files",
+        required=True,
     )
     parser.add_argument(
         "--format", "-f", help="Explicitly specify decoding string", default=None
     )
-    parser.add_argument("--no-log", action="store_true", help="Disable logging", default=False)
+    parser.add_argument(
+        "--no-log", action="store_true", help="Disable logging", default=False
+    )
     parser.add_argument(
         "--log_level",
         "-l",
@@ -298,6 +322,12 @@ def main():
         default=None,
     )
     parser.add_argument(
+        "--continue_on_error",
+        help="Skip and continue processing on errors",
+        default=False,
+        action="store_true",
+    )
+    parser.add_argument(
         "--drop_checksum_suffix",
         action="store_true",
         help="Remove the last two bytes from the payload",
@@ -310,29 +340,48 @@ def main():
         logging.basicConfig(
             level=getattr(logging, args.log_level),
             format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-            stream=sys.stderr
+            stream=sys.stderr,
         )
         root_logger = logging.getLogger()
         root_logger.setLevel(getattr(logging, args.log_level))
 
+    payload_paths = [
+        Path(p) for p_input in args.payload_file_paths for p in glob.glob(p_input)
+    ]
+    payload_paths = sorted(payload_paths, key=lambda p: p.as_posix())
 
-    if isinstance(args.payload_file_path, Path):
-        with open(args.payload_file_path, "rb") as payload_file:
-            payload = payload_file.read()
-    else:
-        # Read payload from stdin
-        payload = sys.stdin.buffer.read()
+    lines = []
+    for payload_file_path in payload_paths:
+        logger.info(f"Parsing {payload_file_path}")
+        try:
+            with open(payload_file_path, "rb") as payload_file:
+                payload = payload_file.read()
 
-    if args.drop_checksum_suffix:
-        payload = payload[:-2]
+            if args.drop_checksum_suffix:
+                payload = payload[:-2]
 
-    decoded = decode_payload(
-        payload,
-        payload_format=args.format,
-        payload_formats_path=args.payload_format_path,
+            data_line = decode_payload(
+                payload,
+                payload_format=args.format,
+                payload_formats_path=args.payload_format_path,
+            )
+
+            lines.append(data_line)
+        except Exception as e:
+            if args.continue_on_error:
+                logger.error(f"Error decoding {payload_file_path}. {e}")
+            else:
+                raise
+
+    df = pd.DataFrame(lines)
+    df.to_csv(
+        sys.stdout,
+        index=False,
+        header=False,
+        date_format="%Y-%m-%d %H:%M:%S",
     )
 
-    return pd.DataFrame([decoded]).to_csv(sys.stdout, index=False, header=False)
 
 if __name__ == "__main__":
+
     main()

--- a/src/pypromice/tx/payload_decoder.py
+++ b/src/pypromice/tx/payload_decoder.py
@@ -20,6 +20,7 @@ __all__ = [
     "DecodeError",
 ]
 
+import pandas as pd
 
 logger = logging.getLogger(__name__)
 
@@ -264,7 +265,7 @@ def decode(bin_format: str, payload: bytes) -> list:
     return dataline
 
 
-if __name__ == "__main__":
+def main():
     import argparse
     import sys
     import pandas as pd
@@ -331,4 +332,7 @@ if __name__ == "__main__":
         payload_formats_path=args.payload_format_path,
     )
 
-    df = pd.DataFrame([decoded]).to_csv(sys.stdout, index=False, header=False)
+    return pd.DataFrame([decoded]).to_csv(sys.stdout, index=False, header=False)
+
+if __name__ == "__main__":
+    main()

--- a/src/pypromice/tx/payload_decoder.py
+++ b/src/pypromice/tx/payload_decoder.py
@@ -147,7 +147,7 @@ def decode_payload(
 def decode(bin_format: str, payload: bytes) -> list:
     payload_length = len(payload)
     logger.info(f"Decoding payload with format: {bin_format!r}. Payload length: {payload_length}")
-    logger.debug(f"Payload: {payload!r}")
+    logger.debug(f"Payload: {payload.hex()!r}")
     # Note: bin_val is just len(bin_format)
     indx = 1  # The first byte is the payload format
     dataline: list = []
@@ -155,7 +155,7 @@ def decode(bin_format: str, payload: bytes) -> list:
     try:
         for format_letter_index, type_letter in enumerate(bin_format):
             logger.debug(
-                f"Index {indx:02n} / {payload_length} Type letter: {type_letter:s}. upcuming bytes: {payload[indx:indx + 6]}..."
+                f"Index {indx:02n} / {payload_length} Type letter: {type_letter:s}. upcuming bytes: {payload[indx:indx+4].hex()}"
             )
 
             if type_letter == "f":


### PR DESCRIPTION
- Added new payload types (`b`, `w`, `c`) to `payload_types.csv` and updated associated formats in `payload_formats.csv`.
- Implemented decoding logic for new types (`b`, `w`, `c`) in `decode` function.
- Refactored `decode_payload` by introducing better modularity and default path handling for payload formats.
- Improved logging and streamlined docstrings for clarity.
- Fixed argument naming inconsistencies and standardized defaults.

TODO: This branch override existing format numbers (25 and 43). Correct the format type numbers to non occupied values to revert to the previous formats before merging.