### PR TITLE
Fixing issues in variable dependency, min filter and tilt interpolation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2025, GEUS Glaciology and Climate'
 author = 'GEUS Glaciology and Climate'
 
 # The full version, including alpha/beta/rc tags
-release = '1.9.4'
+release = '1.10.2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pypromice"
-version = "1.10.1"
+version = "1.10.2"
 description = "PROMICE/GC-Net toolbox for processing data from automatic weather stations"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/pypromice/core/qc/github_data_issues.py
+++ b/src/pypromice/core/qc/github_data_issues.py
@@ -155,9 +155,9 @@ def adjustData(ds, adj_dir, var_list=[], skip_var=[]):
 
         # making sure that t0 and t1 columns are object dtype then replaceing nan with None
         adj_info[['t0','t1']] = adj_info[['t0','t1']].astype(object)
-        adj_info.loc[adj_info.t1.isnull()|(adj_info.t1==''), "t1"] = None      
+        adj_info.loc[adj_info.t1.isnull()|(adj_info.t1==''), "t1"] = None
         adj_info.loc[adj_info.t0.isnull()|(adj_info.t0==''), "t0"] = None
-		
+
         # if "*" is in the variable name then we interpret it as regex
         selec = adj_info['variable'].str.contains(r'\*') & (adj_info['variable'] != "*")
         for ind in adj_info.loc[selec, :].index:
@@ -218,6 +218,7 @@ def adjustData(ds, adj_dir, var_list=[], skip_var=[]):
                 if func == "min_filter":
                     tmp = ds_out[var].loc[index_slice].values
                     tmp[tmp < val] = np.nan
+                    ds_out[var].loc[index_slice] = tmp
 
                 if func == "max_filter":
                     tmp = ds_out[var].loc[index_slice].values
@@ -243,9 +244,9 @@ def adjustData(ds, adj_dir, var_list=[], skip_var=[]):
                         .sel(time=ds_out[var].loc[index_slice].time.values, method='ffill')
                         )
                     df_max['time'] = ds_out[var].loc[index_slice].time
-                    # updating original pandas                   
+                    # updating original pandas
                     ds_out[var].loc[index_slice] = ds_out[var].loc[index_slice].where(ds_out[var].loc[index_slice] > df_max-val)
-                                        
+
 
                 if func == "hampel_filter":
                     tmp = ds_out[var].loc[index_slice]
@@ -272,23 +273,34 @@ def adjustData(ds, adj_dir, var_list=[], skip_var=[]):
                     tmp = tmp.where(~msk)
                     # remove isolated singletons and pairs surrounded by NaNs
                     m1 = tmp.notnull() & tmp.shift(time=1).isnull() & tmp.shift(time=-1).isnull()
-                    
+
                     m2_first  = (tmp.notnull()
                                  & tmp.shift(time=1).isnull()     # left is NaN
                                  & tmp.shift(time=-1).notnull()   # right is value
                                  & tmp.shift(time=-2).isnull())   # right+1 is NaN
-                    
+
                     m2_second = (tmp.notnull()
                                  & tmp.shift(time=-1).isnull()    # right is NaN
                                  & tmp.shift(time=1).notnull()    # left is value
                                  & tmp.shift(time=2).isnull())    # left-1 is NaN
-                    
+
                     tmp = tmp.where(~(m1 | m2_first | m2_second))
                     ds_out[var].loc[index_slice] = tmp.values
 
                 if func == "rotate":
                     ds_out[var].loc[index_slice] = (ds_out[var].loc[index_slice].values + val) % 360
 
+        # specific dependency for boom/stake heights
+        var_dep = {
+            "z_boom_cor_u": "z_boom_u",
+            "z_boom_cor_l": "z_boom_l",
+            "z_stake_cor": "z_stake",
+        }
+
+        for var, dep in var_dep.items():
+            if var in ds_out and dep in ds_out:
+                flagged = ds_out[var].isnull() & ds[var].notnull()
+                ds_out[dep] = ds_out[dep].where(~flagged)
     return ds_out
 
 

--- a/src/pypromice/core/variables/station_pose.py
+++ b/src/pypromice/core/variables/station_pose.py
@@ -82,9 +82,7 @@ def convert_and_filter_tilt(tilt: xr.DataArray
     # Apply filtering mask
     dst = dst.where(~notOKtilt)
 
-    # TODO: Filling w/o considering time gaps to re-create IDL/GDL outputs.
-    #  Should fill with coordinate not False. Also consider 'max_gap' option?
-    return dst.interpolate_na(dim='time', use_coordinate=False)
+    return dst.interpolate_na(dim='time', max_gap="14D")
 
 
 def smooth_tilt_with_moving_window(tilt: xr.DataArray
@@ -151,8 +149,8 @@ def interpolate_tilt(tilt: xr.DataArray,
     # - when tilt is not available for the very first time steps, the first
     #   good value is used for backfill
     return tilt.where(
-                moving_std_gap_filled < tilt_stddev_threshold
-                ).ffill(dim="time").bfill(dim="time")
+                    moving_std_gap_filled < tilt_stddev_threshold
+                ).ffill(dim="time", limit=14*24).bfill(dim="time", limit=14*24)
 
 
 def interpolate_rotation(rot: xr.DataArray,
@@ -180,11 +178,11 @@ def interpolate_rotation(rot: xr.DataArray,
     #     - a two-week median smoothing
     #     - a resampling from these daily values to the original temporal resolution
     return ("time", (rot.where(moving_std_gap_filled < rot_stddev_threshold)
-            .ffill(dim="time")
-            .to_series().resample("D").median()
-            .rolling(7*2,center=True,min_periods=2).median()
-            .reindex(rot.time, method="bfill").values
-            ))
+                    .ffill(dim="time", limit=14*24)
+                    .to_series().resample("D").median()
+                    .rolling(7*2, center=True, min_periods=2).median()
+                    .reindex(rot.time, method="bfill", tolerance=pd.Timedelta("14D")).values
+                ))
 
 
 def calculate_spherical_tilt(

--- a/src/pypromice/resources/variables.csv
+++ b/src/pypromice/resources/variables.csv
@@ -3,8 +3,8 @@ time,time,Time,yyyy-mm-dd HH:MM:SS,physicalMeasurement,time,,,,,,all,1,1,1,
 rec,record,Record,-,referenceInformation,time,,L0 or L2,,,,all,1,1,0,0
 p_u,air_pressure,Air pressure (upper boom),hPa,physicalMeasurement,time,FALSE,,650,1100,z_pt_cor dlhf_u dshf_u,all,1,1,1,4
 p_l,air_pressure,Air pressure (lower boom),hPa,physicalMeasurement,time,FALSE,,650,1100,dlhf_l dshf_l,two-boom,1,1,1,4
-t_u,air_temperature,Air temperature (upper boom),degrees_C,physicalMeasurement,time,FALSE,,-80,40,z_boom_cor_u z_stake_cor qh_u rh_u_wrt_ice_or_water dlhf_u dshf_u,all,1,1,1,4
-t_l,air_temperature,Air temperature (lower boom),degrees_C,physicalMeasurement,time,FALSE,,-80,40,z_boom_cor_l qh_l rh_l_wrt_ice_or_water dlhf_l dshf_l,two-boom,1,1,1,4
+t_u,air_temperature,Air temperature (upper boom),degrees_C,physicalMeasurement,time,FALSE,,-80,40,qh_u rh_u_wrt_ice_or_water dlhf_u dshf_u,all,1,1,1,4
+t_l,air_temperature,Air temperature (lower boom),degrees_C,physicalMeasurement,time,FALSE,,-80,40,qh_l rh_l_wrt_ice_or_water dlhf_l dshf_l,two-boom,1,1,1,4
 rh_u,relative_humidity,Relative humidity (upper boom),%,physicalMeasurement,time,FALSE,,0,100,qh_u rh_u_wrt_ice_or_water dlhf_u dshf_u,all,1,1,1,4
 rh_u_wrt_ice_or_water,relative_humidity_with_respect_to_ice_or_water,Relative humidity (upper boom) with respect to saturation over ice in subfreezing conditions and over water otherwise,%,modelResult,time,FALSE,L2 or later,0,150,"",all,0,1,1,4
 qh_u,specific_humidity,Specific humidity (upper boom),kg/kg,modelResult,time,FALSE,L2 or later,0,100,"",all,0,1,1,4
@@ -34,13 +34,13 @@ dlhf_l,surface_downward_latent_heat_flux,Latent heat flux (lower boom),W m-2,mod
 dshf_u,surface_downward_sensible_heat_flux,Sensible heat flux (upper boom),W m-2,modelResult,time,FALSE,L3 or later,,,,all,0,0,1,4
 dshf_l,surface_downward_sensible_heat_flux,Sensible heat flux (lower boom),W m-2,modelResult,time,FALSE,L3 or later,,,,two-boom,0,0,1,4
 z_boom_u,distance_to_surface_from_boom,Upper boom height,m,physicalMeasurement,time,TRUE,,0.3,10,z_boom_cor_u,all,1,1,1,4
-z_boom_cor_u,distance_to_surface_from_boom_corrected,Upper boom height - corrected,m,modelResult,time,TRUE,,0.3,10,z_boom_u,all,1,1,1,4
+z_boom_cor_u,distance_to_surface_from_boom_corrected,Upper boom height - corrected,m,modelResult,time,TRUE,,0.3,10,,all,1,1,1,4
 z_boom_q_u,distance_to_surface_from_boom_quality,Upper boom height (quality),-,qualityInformation,time,TRUE,L0 or L2,,,,all,1,1,0,4
 z_boom_l,distance_to_surface_from_boom,Lower boom height,m,physicalMeasurement,time,TRUE,,0.3,5,z_boom_cor_l,two-boom,1,1,1,4
-z_boom_cor_l,distance_to_surface_from_boom_corrected,Lower boom height - corrected,m,modelResult,time,TRUE,,0.3,5,z_boom_l,two-boom,1,1,1,4
+z_boom_cor_l,distance_to_surface_from_boom_corrected,Lower boom height - corrected,m,modelResult,time,TRUE,,0.3,5,,two-boom,1,1,1,4
 z_boom_q_l,distance_to_surface_from_boom_quality,Lower boom height (quality),-,qualityInformation,time,TRUE,L0 or L2,,,,two-boom,1,1,0,4
 z_stake,distance_to_surface_from_stake_assembly,Stake height,m,physicalMeasurement,time,TRUE,,0.3,8,z_stake_cor,one-boom,1,1,1,4
-z_stake_cor,distance_to_surface_from_stake_assembly_corrected,Stake height - corrected,m,physicalMeasurement,time,TRUE,,0.3,8,z_stake,one-boom,1,1,1,4
+z_stake_cor,distance_to_surface_from_stake_assembly_corrected,Stake height - corrected,m,physicalMeasurement,time,TRUE,,0.3,8,,one-boom,1,1,1,4
 z_stake_q,distance_to_surface_from_stake_assembly_quality,Stake height (quality),-,qualityInformation,time,TRUE,L0 or L2,,,,one-boom,1,1,0,4
 z_pt,depth_of_pressure_transducer_in_ice,Depth of pressure transducer in ice,m,physicalMeasurement,time,FALSE,,0,30,z_pt_cor,one-boom,1,1,1,4
 z_pt_cor,depth_of_pressure_transducer_in_ice_corrected,Depth of pressure transducer in ice - corrected,m,modelResult,time,FALSE,L2 or later,0,30,,one-boom,0,1,1,4

--- a/src/pypromice/resources/variables.csv
+++ b/src/pypromice/resources/variables.csv
@@ -3,8 +3,8 @@ time,time,Time,yyyy-mm-dd HH:MM:SS,physicalMeasurement,time,,,,,,all,1,1,1,
 rec,record,Record,-,referenceInformation,time,,L0 or L2,,,,all,1,1,0,0
 p_u,air_pressure,Air pressure (upper boom),hPa,physicalMeasurement,time,FALSE,,650,1100,z_pt_cor dlhf_u dshf_u,all,1,1,1,4
 p_l,air_pressure,Air pressure (lower boom),hPa,physicalMeasurement,time,FALSE,,650,1100,dlhf_l dshf_l,two-boom,1,1,1,4
-t_u,air_temperature,Air temperature (upper boom),degrees_C,physicalMeasurement,time,FALSE,,-80,40,qh_u rh_u_wrt_ice_or_water dlhf_u dshf_u,all,1,1,1,4
-t_l,air_temperature,Air temperature (lower boom),degrees_C,physicalMeasurement,time,FALSE,,-80,40,qh_l rh_l_wrt_ice_or_water dlhf_l dshf_l,two-boom,1,1,1,4
+t_u,air_temperature,Air temperature (upper boom),degrees_C,physicalMeasurement,time,FALSE,,-80,40,z_boom_cor_u z_stake_cor qh_u rh_u_wrt_ice_or_water dlhf_u dshf_u,all,1,1,1,4
+t_l,air_temperature,Air temperature (lower boom),degrees_C,physicalMeasurement,time,FALSE,,-80,40,z_boom_cor_l qh_l rh_l_wrt_ice_or_water dlhf_l dshf_l,two-boom,1,1,1,4
 rh_u,relative_humidity,Relative humidity (upper boom),%,physicalMeasurement,time,FALSE,,0,100,qh_u rh_u_wrt_ice_or_water dlhf_u dshf_u,all,1,1,1,4
 rh_u_wrt_ice_or_water,relative_humidity_with_respect_to_ice_or_water,Relative humidity (upper boom) with respect to saturation over ice in subfreezing conditions and over water otherwise,%,modelResult,time,FALSE,L2 or later,0,150,"",all,0,1,1,4
 qh_u,specific_humidity,Specific humidity (upper boom),kg/kg,modelResult,time,FALSE,L2 or later,0,100,"",all,0,1,1,4


### PR DESCRIPTION
## Special dependency of `t_u`, `z_boom` and `z_boom_cor` (and similarly `z_stake`)

Due to this chain of dependency:  missing values in `t_u` impact `z_boom_cor_u` which impact `z_boom_u`, missing temperatures ended up removing `z_boom_u`. Since the latter should contain uncorrected value, this does not work as intended.
The dependency [`z_boom_cor_u` impacts `z_boom_u`] was meant in a filtering purpose: it is easier to identify min/max filters on corrected values, and once those outliers detected in `z_boom_cor_u`, I wanted to also remove them from `z_boom_u`, without noticing that I would create a dependency from `t_u` to `z_boom_u` as explained above.
To avoid that I:
1) Remove the dependency [`z_boom_cor_u` impacts `z_boom_u`]
2) When manually filtering `z_boom_cor_u` the outliers identified are also removed from `z_boom_u`. This is done in the `adjust_data` function and not as a dependency.

This will solve currently missing z_boom_u and surface height at ZAC_Uv3 in spite of a functional SR50.

## min filter
Manual min filters did not remove the data. Fixed now.

## tilt interpolation
As already noted in the script as a TODO, interpolation of tilt values is now limited to 14 days.

This will solve long periods with constant tilt, for instance at TAS_L in 2025.