### PR TITLE
Feature/not printing unnecessary files

### DIFF
--- a/.github/workflows/data_output_reporter.yml
+++ b/.github/workflows/data_output_reporter.yml
@@ -39,7 +39,8 @@ jobs:
           get_l2 -c tests/data/test_config1_raw.toml \
                  -i tests/data/ \
                  -o out/new/ \
-                 --data_issues_path data_issues/pr \
+                 --data_issues_path data_issues/pr
+
           get_l2tol3 -c tests/data/station_configurations/TEST1.toml \
                      -i out/new/TEST1/TEST1_mixed.nc \
                      -o out/new/ \
@@ -78,10 +79,10 @@ jobs:
                  -i tests/data/ \
                  --issues data_issues/main \
                  -o out/original/ \
-                 --data_issues_path data_issues/main \
-                 --write_60min
+                 --data_issues_path data_issues/main
+
           get_l2tol3 -c tests/data/station_configurations/TEST1.toml \
-                     -i out/original/TEST1/TEST1_hour.nc \
+                     -i out/original/TEST1/TEST1_mixed.nc \
                      -o out/original/ \
                      --data_issues_path data_issues/main
 

--- a/.github/workflows/data_output_reporter.yml
+++ b/.github/workflows/data_output_reporter.yml
@@ -39,9 +39,9 @@ jobs:
           get_l2 -c tests/data/test_config1_raw.toml \
                  -i tests/data/ \
                  -o out/new/ \
-                 --data_issues_path data_issues/pr
+                 --data_issues_path data_issues/pr \
           get_l2tol3 -c tests/data/station_configurations/TEST1.toml \
-                     -i out/new/TEST1/TEST1_hour.nc \
+                     -i out/new/TEST1/TEST1_mixed.nc \
                      -o out/new/ \
                      --data_issues_path data_issues/pr
 
@@ -78,7 +78,8 @@ jobs:
                  -i tests/data/ \
                  --issues data_issues/main \
                  -o out/original/ \
-                 --data_issues_path data_issues/main
+                 --data_issues_path data_issues/main \
+                 --write_60min
           get_l2tol3 -c tests/data/station_configurations/TEST1.toml \
                      -i out/original/TEST1/TEST1_hour.nc \
                      -o out/original/ \

--- a/.github/workflows/data_output_reporter.yml
+++ b/.github/workflows/data_output_reporter.yml
@@ -39,12 +39,14 @@ jobs:
           get_l2 -c tests/data/test_config1_raw.toml \
                  -i tests/data/ \
                  -o out/new/ \
-                 --data_issues_path data_issues/pr
+                 --data_issues_path data_issues/pr \
+                 --write_60min
 
           get_l2tol3 -c tests/data/station_configurations/TEST1.toml \
                      -i out/new/TEST1/TEST1_mixed.nc \
                      -o out/new/ \
-                     --data_issues_path data_issues/pr
+                     --data_issues_path data_issues/pr \
+                     --write_60min
 
       # Step 4.5: Upload PR output file as artifact
       - name: Upload PR TEST1_hour.nc

--- a/.github/workflows/process_test.yml
+++ b/.github/workflows/process_test.yml
@@ -50,7 +50,7 @@ jobs:
           mkdir $GITHUB_WORKSPACE/out/L2toL3/
           for i in $(echo ${{ env.TEST_STATION }} | tr ' ' '\n'); do
             echo ${i}_hour.nc
-            python3 $GITHUB_WORKSPACE/main/src/pypromice/pipeline/get_l2tol3.py -c $GITHUB_WORKSPACE/aws-l0/metadata/station_configurations/ -i $GITHUB_WORKSPACE/out/L0toL2/${i}/${i}_hour.nc -o $GITHUB_WORKSPACE/out/L2toL3/ --data_issues_path $GITHUB_WORKSPACE/data_issues
+            python3 $GITHUB_WORKSPACE/main/src/pypromice/pipeline/get_l2tol3.py -c $GITHUB_WORKSPACE/aws-l0/metadata/station_configurations/ -i $GITHUB_WORKSPACE/out/L0toL2/${i}/${i}_mixed.nc -o $GITHUB_WORKSPACE/out/L2toL3/ --data_issues_path $GITHUB_WORKSPACE/data_issues
           done
       - name: Upload test output
         uses: actions/upload-artifact@v4

--- a/src/pypromice/core/variables/station_pose.py
+++ b/src/pypromice/core/variables/station_pose.py
@@ -10,7 +10,7 @@ import xarray as xr
 import pandas as pd
 
 tilt_smoothing_win_size = 7 # Station tilt smoothing window size
-tilt_stddev_threshold = 0.2 # Station tilt interpolation standard deviation threshold
+tilt_stddev_threshold = 0.3 # Station tilt interpolation standard deviation threshold
 rot_stddev_threshold = 4    # Station rotation interpolation standard deviation threshold
 tilt_threshold = -100       # Station tilt threshold
 deg2rad = np.pi / 180       # Degrees to radians conversion
@@ -140,17 +140,48 @@ def interpolate_tilt(tilt: xr.DataArray,
     # We calculate the moving standard deviation over a 3-day sliding window
     # hourly resampling is necessary to make sure the same threshold can be used
     # for 10 min and hourly data
-    moving_std_gap_filled = tilt.to_series().resample("h").median().rolling(
-                    3*24, center=True, min_periods=2
-                    ).std().reindex(tilt.time, method="bfill").values
+    moving_std_gap_filled = (
+                    tilt.to_series()
+                    .resample("h")
+                    .median()
+                    .rolling(3 * 24, center=True, min_periods=2)
+                    .std()
+                    .reindex(tilt.time, method="bfill")
+                    .values
+                )
+
+    tilt_filtered = tilt.where(moving_std_gap_filled < tilt_stddev_threshold)
 
     # We select the good timestamps and gapfill assuming that
-    # - when tilt goes missing the last available value is used
+    # - when tilt goes missing the last available value is used for the next 30 days
     # - when tilt is not available for the very first time steps, the first
-    #   good value is used for backfill
-    return tilt.where(
-                    moving_std_gap_filled < tilt_stddev_threshold
-                ).ffill(dim="time", limit=28*24).bfill(dim="time", limit=28*24)
+    #   good value is used for backfilling the previous 30 days
+    tilt_hourly = tilt_filtered.resample(time="1h").median()
+
+    tilt_hourly_filled = (
+        tilt_hourly
+        .ffill(dim="time", limit=30 * 24)
+        .bfill(dim="time", limit=30 * 24)
+    )
+
+    was_filled_hourly = tilt_hourly.isnull() & tilt_hourly_filled.notnull()
+
+    was_filled_at_original_time = (
+        was_filled_hourly
+        .reindex(time=tilt.time, method="nearest", tolerance=np.timedelta64(30, "m"))
+        .fillna(False)
+    )
+
+    tilt_filled_at_original_time = (
+        tilt_hourly_filled
+        .reindex(time=tilt.time, method="nearest", tolerance=np.timedelta64(30, "m"))
+    )
+
+    return tilt_filtered.where(
+        ~was_filled_at_original_time,
+        tilt_filled_at_original_time,
+    )
+
 
 
 def interpolate_rotation(rot: xr.DataArray,

--- a/src/pypromice/core/variables/station_pose.py
+++ b/src/pypromice/core/variables/station_pose.py
@@ -168,20 +168,24 @@ def interpolate_tilt(tilt: xr.DataArray,
 
     was_filled_at_original_time = (
         was_filled_hourly
-        .reindex(time=tilt.time, method="nearest", tolerance=np.timedelta64(30, "m"))
+        .reindex(time=tilt.time,
+                 method="nearest",
+                 tolerance=np.timedelta64(30, "m"))
         .fillna(False)
+        .astype(bool)
     )
 
     tilt_filled_at_original_time = (
         tilt_hourly_filled
-        .reindex(time=tilt.time, method="nearest", tolerance=np.timedelta64(30, "m"))
+        .reindex(time=tilt.time,
+                 method="nearest",
+                 tolerance=np.timedelta64(30, "m"))
     )
 
     return tilt_filtered.where(
         ~was_filled_at_original_time,
         tilt_filled_at_original_time,
     )
-
 
 
 def interpolate_rotation(rot: xr.DataArray,

--- a/src/pypromice/io/write.py
+++ b/src/pypromice/io/write.py
@@ -24,6 +24,7 @@ def prepare_and_write(
         time="60min",
         resample=True,
         nc_compression:bool=False,
+        write_csv = True,
 ):
     """Prepare data with resampling, formating and metadata population; then
     write data to .nc and .csv hourly and daily files
@@ -118,7 +119,8 @@ def prepare_and_write(
 
     # Write to csv file
     logger.info("Writing to files...")
-    writeCSV(out_csv, d2, col_names)
+    if write_csv:
+        writeCSV(out_csv, d2, col_names)
 
     # Write to netcdf file
     writeNC(out_nc, d2, col_names, compression=nc_compression)

--- a/src/pypromice/pipeline/L2toL3.py
+++ b/src/pypromice/pipeline/L2toL3.py
@@ -172,21 +172,23 @@ def process_surface_height(ds, data_adjustments_dir, station_config={}):
     ds['z_surf_1'] = ('time', ds['z_boom_u'].data * np.nan)
     ds['z_surf_2'] = ('time', ds['z_boom_u'].data * np.nan)
 
-    z_boom_best_u = station_boom_height.include_uncorrected_values(
-                                ds["z_boom_u"],
-                                ds["z_boom_cor_u"],
-                                ds["t_l"] if "t_l" in ds.data_vars else None,
-                                ds["t_rad"] if "t_rad" in ds.data_vars else None)
+    z_boom_best_u = ds["z_boom_cor_u"]
+    # z_boom_best_u = station_boom_height.include_uncorrected_values(
+    #                             ds["z_boom_u"],
+    #                             ds["z_boom_cor_u"],
+    #                             ds["t_l"] if "t_l" in ds.data_vars else None,
+    #                             ds["t_rad"] if "t_rad" in ds.data_vars else None)
 
 
 
     if 'z_stake' in ds.data_vars and ds.z_stake.notnull().any():
         # Calculate stake boom height correction with uncorrected values where needed
-        z_stake_best = station_boom_height.include_uncorrected_values(
-                                    ds["z_stake"],
-                                    ds["z_stake_cor"],
-                                    ds["t_l"] if "t_l" in ds.data_vars else None,
-                                    ds["t_rad"] if "t_rad" in ds.data_vars else None)
+        z_stake_best = ds["z_stake_cor"]
+        # z_stake_best = station_boom_height.include_uncorrected_values(
+        #                             ds["z_stake"],
+        #                             ds["z_stake_cor"],
+        #                             ds["t_l"] if "t_l" in ds.data_vars else None,
+        #                             ds["t_rad"] if "t_rad" in ds.data_vars else None)
 
     if ds.attrs['site_type'] == 'ablation':
         # Calculate surface heights for ablation sites
@@ -211,11 +213,12 @@ def process_surface_height(ds, data_adjustments_dir, station_config={}):
         if 'z_boom_l' in ds.data_vars:
 
             # Calculate lower boom height correction with uncorrected values where needed
-            z_boom_best_l = station_boom_height.include_uncorrected_values(
-                                        ds["z_boom_l"],
-                                        ds["z_boom_cor_l"],
-                                        ds["t_u"] if "t_u" in ds.data_vars else None,
-                                        ds["t_rad"] if "t_rad" in ds.data_vars else None)
+            z_boom_best_l = ds["z_boom_cor_l"]
+            # z_boom_best_l = station_boom_height.include_uncorrected_values(
+            #                             ds["z_boom_l"],
+            #                             ds["z_boom_cor_l"],
+            #                             ds["t_u"] if "t_u" in ds.data_vars else None,
+            #                             ds["t_rad"] if "t_rad" in ds.data_vars else None)
 
             # need a combine first because KAN_U switches from having a z_stake_best
             # to having a z_boom_best_l

--- a/src/pypromice/pipeline/L2toL3.py
+++ b/src/pypromice/pipeline/L2toL3.py
@@ -1027,9 +1027,16 @@ def gps_coordinate_postprocessing(ds, var, station_config={}):
         else:
             logger.info('processing '+var+' with relocation on ' + ', '.join([br.strftime('%Y-%m-%dT%H:%M:%S') for br in breaks]))
 
-        return piecewise_smoothing_and_interpolation(ds[var].to_series(), breaks)
+        return piecewise_smoothing_and_interpolation(
+                    ds[var].to_series(),
+                    breaks,
+                    use_mean=(
+                        var == 'gps_alt'
+                        and ds.attrs.get('site_type') == 'accumulation'
+                    )
+                )
 
-def piecewise_smoothing_and_interpolation(data_series, breaks):
+def piecewise_smoothing_and_interpolation(data_series, breaks, use_mean=False):
     '''Smoothes, inter- or extrapolate the GPS observations. The processing is
     done piecewise so that each period between station relocations are done
     separately (no smoothing of the jump due to relocation). Piecewise linear
@@ -1051,37 +1058,45 @@ def piecewise_smoothing_and_interpolation(data_series, breaks):
     np.ndarray
         Smoothed and interpolated values corresponding to the input series.
     '''
-    df_all = pd.Series(dtype=float)  # Initialize an empty Series to gather all smoothed pieces
     breaks = [None] + breaks + [None]
     _inferred_series = []
+
     for i in range(len(breaks) - 1):
         df = data_series.loc[slice(breaks[i], breaks[i+1])]
 
-        # Drop NaN values and calculate the number of segments based on valid data
         df_valid = df.dropna()
+
         if df_valid.shape[0] > 2:
-            # Fit linear regression model to the valid data range
-            x = pd.to_numeric(df_valid.index).values.reshape(-1, 1)
-            y = df_valid.values.reshape(-1, 1)
 
-            model = LinearRegression()
-            model.fit(x, y)
+            if use_mean:
+                # Fill whole segment with mean value
+                y_pred = np.full(len(df), df_valid.mean())
+                df = pd.Series(y_pred, index=df.index)
 
-            # Predict using the model for the entire segment range
-            x_pred = pd.to_numeric(df.index).values.reshape(-1, 1)
+            else:
+                # Linear regression
+                x = pd.to_numeric(df_valid.index).values.reshape(-1, 1)
+                y = df_valid.values.reshape(-1, 1)
 
-            y_pred = model.predict(x_pred)
-            df =  pd.Series(y_pred.flatten(), index=df.index)
-        # adds to list the predicted values for the current segment
+                model = LinearRegression()
+                model.fit(x, y)
+
+                x_pred = pd.to_numeric(df.index).values.reshape(-1, 1)
+                y_pred = model.predict(x_pred)
+
+                df = pd.Series(y_pred.flatten(), index=df.index)
+
         _inferred_series.append(df)
 
     df_all = pd.concat(_inferred_series)
 
-    # Fill internal gaps with linear interpolation
-    df_all = df_all.interpolate(method='linear', limit_area='inside')
+    df_all = df_all.interpolate(
+        method='linear',
+        limit_area='inside'
+    )
 
-    # Remove duplicate indices and return values as numpy array
     df_all = df_all[~df_all.index.duplicated(keep='last')]
+
     return df_all.values
 
 def calculate_turbulent_heat_fluxes(T_0, T_h, Tsurf_h, WS_h, z_WS, z_T, q_h, p_h,

--- a/src/pypromice/pipeline/get_l2.py
+++ b/src/pypromice/pipeline/get_l2.py
@@ -23,11 +23,52 @@ def parse_arguments_l2():
     parser.add_argument('-m', '--metadata', default=None, type=str,
                         required=False, help='File path to metadata')
     parser.add_argument('--data_issues_path', '--issues', default=None, help="Path to data issues repository")
+    parser.add_argument('--write_csv', action='store_true',
+                        help='Write CSV files in addition to NetCDF')
+    parser.add_argument('--write_10min', action='store_true',
+                        help='Write 10-minute resampled output')
+    parser.add_argument('--write_60min', action='store_true',
+                        help='Write 60-minute resampled output')
     args = parser.parse_args()
     return args
 
 
-def get_l2(config_file, inpath, outpath, variables, metadata, data_issues_path: Path) -> AWS:
+def get_l2(
+    config_file: str,
+    inpath: str,
+    outpath: str | None = None,
+    variables: str | None = None,
+    metadata: str | None = None,
+    data_issues_path: Path | None = None,
+    write_csv: bool = False,
+    write_10min: bool = False,
+    write_60min: bool = False,
+) -> AWS:
+    """Process PROMICE AWS data to Level 2.
+
+    Loads AWS data from the provided configuration and input path,
+    performs Level 1 and Level 2 processing, writes the netcdf 'mixed' file
+    to disk and and optionally writes 10min- and hourly resampled files.
+
+    Args:
+        config_file: Path to the station TOML configuration file.
+        inpath: Path to input data directory or files.
+        outpath: Directory where output files are written.
+        variables: Path to variables lookup table.
+        metadata: Path to metadata file.
+        data_issues_path: Path to PROMICE-AWS-data-issues repository.
+        write_csv: If True, write CSV output files.
+        write_10min: If True, write 10-minute resampled products.
+        write_60min: If True, write 60-minute resampled products.
+
+    Returns:
+        Processed AWS object containing Level 1 and Level 2 datasets.
+
+    Raises:
+        ValueError: If data_issues_path is missing and no default
+            repository can be found.
+    """
+
     # Define input path
     station_name = config_file.split('/')[-1].split('.')[0]
     station_path = os.path.join(inpath, station_name)
@@ -60,10 +101,19 @@ def get_l2(config_file, inpath, outpath, variables, metadata, data_issues_path: 
     if outpath is not None:
         if not os.path.isdir(outpath):
             os.mkdir(outpath)
-        prepare_and_write(aws.L2, outpath, aws.vars, aws.meta, 'mixed', resample=False)
-        if aws.L2.attrs['format'] == 'raw':
-            prepare_and_write(aws.L2, outpath, aws.vars, aws.meta, '10min')
-        prepare_and_write(aws.L2, outpath, aws.vars, aws.meta, '60min')
+        prepare_and_write(aws.L2,
+                          outpath,
+                          aws.vars,
+                          aws.meta,
+                          'mixed',
+                          resample=False,
+                          write_csv=write_csv)
+        if (aws.L2.attrs['format'] == 'raw') and write_10min:
+            prepare_and_write(aws.L2, outpath, aws.vars, aws.meta, '10min',
+                              resample=True, write_csv=write_csv)
+        if write_60min :
+            prepare_and_write(aws.L2, outpath, aws.vars, aws.meta, '60min',
+                          resample=True, write_csv=write_csv)
     return aws
 
 
@@ -83,6 +133,9 @@ def main():
         args.variables,
         args.metadata,
         args.data_issues_path,
+        args.write_csv,
+        args.write_10min,
+        args.write_60min,
     )
 
 

--- a/src/pypromice/pipeline/get_l2.py
+++ b/src/pypromice/pipeline/get_l2.py
@@ -111,9 +111,14 @@ def get_l2(
         if (aws.L2.attrs['format'] == 'raw') and write_10min:
             prepare_and_write(aws.L2, outpath, aws.vars, aws.meta, '10min',
                               resample=True, write_csv=write_csv)
-        if write_60min :
+        # the level 2/tx/*_hour.csv file is used for buffer processing
+        # so this file should always be produced
+        if (aws.L2.attrs['format'] == 'tx'):
             prepare_and_write(aws.L2, outpath, aws.vars, aws.meta, '60min',
-                          resample=True, write_csv=write_csv)
+                      resample=True, write_csv=True)
+        elif write_60min:
+            prepare_and_write(aws.L2, outpath, aws.vars, aws.meta, '60min',
+                      resample=True, write_csv=write_csv)
     return aws
 
 

--- a/src/pypromice/pipeline/get_l2tol3.py
+++ b/src/pypromice/pipeline/get_l2tol3.py
@@ -14,6 +14,7 @@ def parse_arguments_l2tol3(debug_args=None):
     parser = ArgumentParser(description="AWS L3 script for the processing L3 "+
                             "data from L2. An hourly, daily and monthly L3 "+
                             "data product is outputted to the defined output path")
+
     parser.add_argument('-c', '--config_folder', type=str, required=True,
                         default='../aws-l0/metadata/station_configurations/',
                         help='Path to folder with sites configuration (TOML) files')
@@ -25,13 +26,30 @@ def parse_arguments_l2tol3(debug_args=None):
                         required=False, help='File path to variables look-up table')
     parser.add_argument('-m', '--metadata', default=None, type=str,
                         required=False, help='File path to metadata')
-    parser.add_argument('--data_issues_path', '--issues', default=None, help="Path to data issues repository")
+    parser.add_argument('--data_issues_path', '--issues', default=None,
+                        help="Path to data issues repository")
 
+    parser.add_argument('--write_60min', action='store_true',
+                        help='Write hourly (60min) Level 3 product')
+    parser.add_argument('--write_1D', action='store_true',
+                        help='Write daily (1D) Level 3 product')
+    parser.add_argument('--write_MS', action='store_true',
+                        help='Write monthly (MS) Level 3 product')
 
     args = parser.parse_args(args=debug_args)
     return args
 
-def get_l2tol3(config_folder: Path|str, inpath, outpath, variables, metadata, data_issues_path: Path|str):
+def get_l2tol3(
+        config_folder: Path | str,
+        inpath,
+        outpath,
+        variables,
+        metadata,
+        data_issues_path: Path | str,
+        write_60min: bool = False,
+        write_1D: bool = False,
+        write_MS: bool = False,
+    ):
     if isinstance(config_folder, str):
         config_folder = Path(config_folder)
 
@@ -91,9 +109,14 @@ def get_l2tol3(config_folder: Path|str, inpath, outpath, variables, metadata, da
     m = pypromice.resources.load_metadata(metadata)
     if outpath is not None:
         prepare_and_write(l3, outpath, v, m, 'mixed', resample=False)
-        prepare_and_write(l3, outpath, v, m, '60min')
-        prepare_and_write(l3, outpath, v, m, '1D')
-        prepare_and_write(l3, outpath, v, m, 'MS')
+        if write_60min:
+            prepare_and_write(l3, outpath, v, m, '60min')
+
+        if write_1D:
+            prepare_and_write(l3, outpath, v, m, '1D')
+
+        if write_MS:
+            prepare_and_write(l3, outpath, v, m, 'MS')
     return l3
 
 def main():

--- a/src/pypromice/pipeline/join_l3.py
+++ b/src/pypromice/pipeline/join_l3.py
@@ -312,27 +312,25 @@ def align_surface_heights(data_series_new, data_series_old):
         # Align based on the median values
         data_series_new = data_series_new - first_week_new + last_week_old
     else:
-        # Perform a linear fit on the last 5x365x24 non-nan values
-        hours_in_5_years = 5 * 365 * 24
+        data_series_old_last_5_years = data_series_old.loc[
+            last_old_idx - pd.Timedelta(days=5 * 365):last_old_idx
+        ].dropna()
 
-        # Drop NaN values and extract the last `hours_in_5_years` non-NaN data points
-        data_series_old_nonan = data_series_old.dropna()
-        data_series_old_last_5_years = data_series_old_nonan.iloc[
-            -min(len(data_series_old), hours_in_5_years):
-        ]
+        x_old = (
+                    data_series_old_last_5_years.index - last_old_idx
+                ).total_seconds() / 86400
+        y_old = data_series_old_last_5_years.values
 
-        # Perform a linear fit on the last 5 years of data
-        fit = np.polyfit(
-            data_series_old_last_5_years.index.astype("int64"),
-            data_series_old_last_5_years.values,
-            1,
-        )
+        fit = np.polyfit(x_old, y_old, 1)
         fit_fn = np.poly1d(fit)
 
+        x_first_new = (first_new_idx - last_old_idx).total_seconds() / 86400
+        expected_old_at_first_new = fit_fn(x_first_new)
+
         data_series_new = (
-            data_series_new.values
-            + fit_fn(data_series_new.index.astype("int64")[0])
-            - data_series_new[first_new_idx]
+            data_series_new
+            + expected_old_at_first_new
+            - data_series_new.loc[first_new_idx]
         )
 
     return data_series_new
@@ -519,7 +517,8 @@ def join_l3(config_folder, site, folder_l3, folder_gcnet,
                     l3_merged["z_ice_surf"] = (
                         "time",
                         align_surface_heights(
-                            l3_merged.z_ice_surf.to_series(), l3.z_ice_surf.to_series()
+                            l3_merged.z_ice_surf.to_series(),
+                            l3.z_ice_surf.to_series()
                         ),
                     )
 

--- a/tests/e2e/test_get_l2.py
+++ b/tests/e2e/test_get_l2.py
@@ -29,6 +29,9 @@ class GetL2TestCase(unittest.TestCase):
                 data_issues_path=data_issues_path,
                 variables=None,
                 metadata=None,
+                write_csv=True,
+                write_10min=True,
+                write_60min=True,
             )
 
             station_id = "TEST1"
@@ -57,6 +60,9 @@ class GetL2TestCase(unittest.TestCase):
                 data_issues_path=data_issues_path,
                 variables=None,
                 metadata=None,
+                write_csv=True,
+                write_10min=True,
+                write_60min=True,
             )
 
             station_id = "TEST1"

--- a/tests/e2e/test_process.py
+++ b/tests/e2e/test_process.py
@@ -117,6 +117,9 @@ class TestProcess(unittest.TestCase):
                 data_issues_path=data_issues_path,
                 variables=None,
                 metadata=None,
+                write_csv=True,
+                write_10min=True,
+                write_60min=True,
             )
             aws_raw_l2 = get_l2(
                 config_file=config_file_raw.as_posix(),
@@ -125,6 +128,9 @@ class TestProcess(unittest.TestCase):
                 data_issues_path=data_issues_path,
                 variables=None,
                 metadata=None,
+                write_csv=True,
+                write_10min=True,
+                write_60min=True,
             )
             #   TODO: This step ignores 10 min data in the join step
             hourly_out_path_tx = output_path_tx / station_id / f"{station_id}_hour.nc"
@@ -141,7 +147,7 @@ class TestProcess(unittest.TestCase):
                 variables=None,
                 metadata=None,
             )
-            hourly_out_path_join = output_l2_join / station_id / f"{station_id}_hour.nc"
+            hourly_out_path_join = output_l2_join / station_id / f"{station_id}_mixed.nc"
             self.assertTrue(hourly_out_path_join.exists())
 
             # Part 3 - Level 2 to level 3

--- a/tests/e2e/test_process.py
+++ b/tests/e2e/test_process.py
@@ -117,9 +117,6 @@ class TestProcess(unittest.TestCase):
                 data_issues_path=data_issues_path,
                 variables=None,
                 metadata=None,
-                write_csv=True,
-                write_10min=True,
-                write_60min=True,
             )
             aws_raw_l2 = get_l2(
                 config_file=config_file_raw.as_posix(),
@@ -128,9 +125,6 @@ class TestProcess(unittest.TestCase):
                 data_issues_path=data_issues_path,
                 variables=None,
                 metadata=None,
-                write_csv=True,
-                write_10min=True,
-                write_60min=True,
             )
             #   TODO: This step ignores 10 min data in the join step
             hourly_out_path_tx = output_path_tx / station_id / f"{station_id}_hour.nc"
@@ -186,26 +180,25 @@ class TestProcess(unittest.TestCase):
                     self.assertTrue(expected_output_path.exists())
 
             for output_rel_path in [
-                "station_l2_raw/TEST1/TEST1_10min.csv",
-                "station_l2_raw/TEST1/TEST1_10min.nc",
-                "station_l2_raw/TEST1/TEST1_hour.csv",
-                "station_l2_raw/TEST1/TEST1_hour.nc",
-                "station_l2_tx/TEST1/TEST1_hour.csv",
+                "station_l2_raw/TEST1/TEST1_mixed.nc", # needed in next processing step
+
+                "station_l2_tx/TEST1/TEST1_mixed.nc", # needed in next processing step
+                "station_l2_tx/TEST1/TEST1_hour.csv", # needed for buffer processing
                 "station_l2_tx/TEST1/TEST1_hour.nc",
-                "station_l2_join/TEST1/TEST1_hour.csv",
-                "station_l2_join/TEST1/TEST1_hour.nc",
-                "station_l3/TEST1/TEST1_day.csv",
-                "station_l3/TEST1/TEST1_day.nc",
-                "station_l3/TEST1/TEST1_hour.csv",
-                "station_l3/TEST1/TEST1_hour.nc",
-                "station_l3/TEST1/TEST1_month.csv",
-                "station_l3/TEST1/TEST1_month.nc",
-                "site_l3/SITE_01/SITE_01_day.csv",
-                "site_l3/SITE_01/SITE_01_day.nc",
-                "site_l3/SITE_01/SITE_01_hour.csv",
-                "site_l3/SITE_01/SITE_01_hour.nc",
-                "site_l3/SITE_01/SITE_01_month.csv",
-                "site_l3/SITE_01/SITE_01_month.nc",
+
+                "station_l2_join/TEST1/TEST1_mixed.csv",
+                "station_l2_join/TEST1/TEST1_mixed.nc", # needed in next processing step
+                "station_l2_join/TEST1/TEST1_hour.csv", # published on thredds
+                "station_l2_join/TEST1/TEST1_hour.nc", # published on thredds
+
+                "station_l3/TEST1/TEST1_mixed.nc", # needed in next processing step
+
+                "site_l3/SITE_01/SITE_01_day.csv", # published on thredds
+                "site_l3/SITE_01/SITE_01_day.nc", # published on thredds
+                "site_l3/SITE_01/SITE_01_hour.csv", # published on thredds
+                "site_l3/SITE_01/SITE_01_hour.nc", # published on thredds
+                "site_l3/SITE_01/SITE_01_month.csv", # published on thredds
+                "site_l3/SITE_01/SITE_01_month.nc", # published on thredds
             ]:
                 output_path = root / output_rel_path
                 self.assertTrue(output_path.exists())
@@ -222,9 +215,8 @@ class TestProcess(unittest.TestCase):
 
             # Test if the l3 output netcdf files are compressed with zlib
             for output_rel_path in [
-                "station_l3/TEST1/TEST1_day.nc",
-                "station_l3/TEST1/TEST1_hour.nc",
-                "station_l3/TEST1/TEST1_month.nc",
+                "station_l3/TEST1/TEST1_mixed.nc",
+
                 "site_l3/SITE_01/SITE_01_day.nc",
                 "site_l3/SITE_01/SITE_01_hour.nc",
                 "site_l3/SITE_01/SITE_01_month.nc",

--- a/tests/e2e/test_process.py
+++ b/tests/e2e/test_process.py
@@ -127,29 +127,29 @@ class TestProcess(unittest.TestCase):
                 metadata=None,
             )
             #   TODO: This step ignores 10 min data in the join step
-            hourly_out_path_tx = output_path_tx / station_id / f"{station_id}_hour.nc"
-            hourly_out_path_raw = output_path_raw / station_id / f"{station_id}_hour.nc"
-            self.assertTrue(hourly_out_path_tx.exists())
-            self.assertTrue(hourly_out_path_raw.exists())
+            mixed_out_path_tx = output_path_tx / station_id / f"{station_id}_mixed.nc"
+            mixed_out_path_raw = output_path_raw / station_id / f"{station_id}_mixed.nc"
+            self.assertTrue(mixed_out_path_tx.exists())
+            self.assertTrue(mixed_out_path_raw.exists())
 
             # Part 2 - Merge level 2 raw and tx data
             output_l2_join = root / "station_l2_join"
             aws_join_l2 = join_l2(
-                hourly_out_path_raw.as_posix(),
-                hourly_out_path_tx.as_posix(),
+                mixed_out_path_raw.as_posix(),
+                mixed_out_path_tx.as_posix(),
                 outpath=output_l2_join.as_posix(),
                 variables=None,
                 metadata=None,
             )
-            hourly_out_path_join = output_l2_join / station_id / f"{station_id}_mixed.nc"
-            self.assertTrue(hourly_out_path_join.exists())
+            mixed_out_path_join = output_l2_join / station_id / f"{station_id}_mixed.nc"
+            self.assertTrue(mixed_out_path_join.exists())
 
             # Part 3 - Level 2 to level 3
             site_id = "SITE_01"
             output_l3 = root / "station_l3"
             aws_station_l3 = get_l2tol3(
                 config_folder=STATION_CONFIGURATIONS_ROOT,
-                inpath=hourly_out_path_join.as_posix(),
+                inpath=mixed_out_path_join.as_posix(),
                 outpath=output_l3.as_posix(),
                 variables=None,
                 metadata=None,

--- a/tests/unit/variables/test_humidity.py
+++ b/tests/unit/variables/test_humidity.py
@@ -8,7 +8,7 @@ from pypromice.core.variables.humidity import adjust, calculate_specific_humidit
 
 class TestHumidityProcessing(unittest.TestCase):
     def setUp(self):
-        self.time = pd.date_range("2025-08-01", periods=12, freq="H")
+        self.time = pd.date_range("2025-08-01", periods=12, freq="h")
         # Temperatures: mix of freezing and above freezing, and NaNs
         t_values = [-10, np.nan, -2, 0, 1, 3, 5, 7, np.nan, 12, 15, 18]
         self.t = xr.DataArray(t_values, coords=[("time", self.time)])

--- a/tests/unit/variables/test_wind.py
+++ b/tests/unit/variables/test_wind.py
@@ -11,7 +11,7 @@ from pypromice.core.variables.wind import (
 
 class TestWindProcessing(unittest.TestCase):
     def setUp(self):
-        self.time = pd.date_range("2025-08-01", periods=4, freq="H")
+        self.time = pd.date_range("2025-08-01", periods=4, freq="h")
         self.wspd = xr.DataArray([0.0, 2.0, 4.0, 6.0], coords=[("time", self.time)])
         self.wdir = xr.DataArray([0.0, 90.0, 180.0, 270.0], coords=[("time", self.time)])
 


### PR DESCRIPTION
This PR makes the writing of different files optional. With default setting not printing the files indicated below:

<img width="1908" height="1001" alt="billede" src="https://github.com/user-attachments/assets/23996f4f-0abd-4d38-8803-2db799e1a084" />

https://docs.google.com/presentation/d/1tpZa_FFFrNFDj5YMlpYv8yyGR0MvnUtpmzTiY_g7bw0/edit?usp=sharing

There are also small fixes including:
- smarter surface height alignment in join_l3
- for accumulation stations `alt` is now the average of `gps_alt` between two relocations (instead of  linear regression)
- update of tilt gap-filling: limited to 30 days instead of on a fixed number of samples