### PR TITLE
Add temperature-dependent humidity recalibration method 

### DIFF
--- a/src/pypromice/core/variables/humidity_recalibration.py
+++ b/src/pypromice/core/variables/humidity_recalibration.py
@@ -1,0 +1,1006 @@
+﻿"""
+rh_recal.envelope
+
+Fixed-P95 temperature-dependent RH upper-envelope fitting.
+
+Final method
+------------
+- Use only temperatures below 0 deg C.
+- Use 2 deg C temperature bins.
+- Require at least 40 observations for a statistical bin.
+- Calculate P95 only.
+- No adaptive P90/P95/P99 switching.
+- No density-branch selection.
+- If real observations extend colder than the first valid P95 bin,
+  optionally use a sparse cold-tail support point.
+- The cold-tail support point is NOT labelled P95.
+- No artificial cold-tail blending toward 100 % saturation.
+- Fit the supported envelope using PCHIP.
+- Derive a bounded multiplicative RH correction factor.
+
+Correction
+----------
+    factor(T) = physical_saturation / fitted_envelope(T)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import numpy as np
+import pandas as pd
+from scipy.interpolate import PchipInterpolator
+
+
+__all__ = [
+    "EnvelopeConfig",
+    "EnvelopeResult",
+    "fit_envelope",
+    "apply_correction",
+]
+
+
+# ============================================================
+# CONFIGURATION
+# ============================================================
+
+
+@dataclass
+class EnvelopeConfig:
+    """
+    Configuration for fixed-P95 envelope fitting.
+    """
+
+    # Temperature range
+    t_min: float = -70.0
+    t_max: float = 0.0
+
+    # Final scientific settings
+    bin_width: float = 2.0
+    percentile: float = 0.95
+    min_points_per_bin: int = 40
+
+    # Basic RH screening
+    rh_min: float = 20.0
+    rh_max: float = 130.0
+
+    # Saturation target
+    physical_saturation: float = 100.0
+
+    # Maximum RH used only for the QC/display output.
+    # The scientific rh_corrected variable remains uncapped.
+    max_corrected_rh: float = 100.0
+
+    # Correction-factor limits
+    min_factor: float = 0.80
+    max_factor: float = 1.35
+
+    @property
+    def min_correction_factor(self) -> float:
+        """Backward-compatible alias for min_factor."""
+        return self.min_factor
+
+    @property
+    def max_correction_factor(self) -> float:
+        """Backward-compatible alias for max_factor."""
+        return self.max_factor
+
+    # Interpolation grid
+    grid_points: int = 600
+
+    # Sparse cold-tail support
+    cold_tail_min_points: int = 8
+    cold_tail_max_points: int = 30
+    cold_tail_quantile: float = 0.50
+
+    # --------------------------------------------------------
+    # Compatibility with older config files
+    # --------------------------------------------------------
+    #
+    # These are retained because default_config.toml may still
+    # contain them. They are NOT used for adaptive percentile
+    # selection.
+
+    q_dense: float = 0.95
+    q_sparse: float = 0.95
+    sparse_threshold: int = 40
+
+    @classmethod
+    def from_dict(
+        cls,
+        values: dict | None,
+    ) -> "EnvelopeConfig":
+        """
+        Construct EnvelopeConfig from a dictionary.
+
+        Unknown old configuration options are ignored.
+
+        The final method is forced to:
+            bin width = 2 deg C
+            percentile = P95
+            minimum observations = 40
+        """
+
+        if not values:
+            cfg = cls()
+
+        else:
+            valid_fields = set(
+                cls.__dataclass_fields__.keys()
+            )
+
+            clean = {
+                key: value
+                for key, value in values.items()
+                if key in valid_fields
+            }
+
+            cfg = cls(
+                **clean
+            )
+
+        # ----------------------------------------------------
+        # Force final scientific method
+        # ----------------------------------------------------
+
+        cfg.bin_width = 2.0
+        cfg.percentile = 0.95
+        cfg.min_points_per_bin = 40
+
+        # Old fields are retained only for compatibility.
+        cfg.q_dense = 0.95
+        cfg.q_sparse = 0.95
+        cfg.sparse_threshold = 40
+
+        return cfg
+
+
+# ============================================================
+# OUTPUT CONTAINER
+# ============================================================
+
+
+@dataclass
+class EnvelopeResult:
+    """
+    Output from fit_envelope().
+
+    factor_at() provides the temperature-dependent correction
+    factor required by correction.py.
+    """
+
+    grid_T: np.ndarray
+    envelope: np.ndarray
+    factor: np.ndarray
+    binned: pd.DataFrame
+
+    diagnostics: dict = field(
+        default_factory=dict
+    )
+
+    def factor_at(
+        self,
+        temperature,
+    ):
+        """
+        Evaluate the fitted correction factor at temperature.
+        """
+
+        values = np.asarray(
+            temperature,
+            dtype=float,
+        )
+
+        result = np.interp(
+            values,
+            self.grid_T,
+            self.factor,
+            left=float(self.factor[0]),
+            right=1.0,
+        )
+
+        if np.ndim(temperature) == 0:
+            return float(result)
+
+        return result
+
+
+
+# ============================================================
+# APPLY RH CORRECTION
+# ============================================================
+
+
+def apply_correction(
+    frame: pd.DataFrame,
+    envelope: EnvelopeResult,
+    cfg: EnvelopeConfig,
+) -> pd.DataFrame:
+    """
+    Apply the fitted temperature-dependent multiplicative
+    RH correction.
+
+    The scientific corrected RH is kept uncapped.
+    A separate capped variable is provided only for QC/display.
+    """
+
+    out = frame.copy()
+
+    factor = envelope.factor_at(
+        out["T"].to_numpy(dtype=float)
+    )
+
+    corrected = (
+        out["rh"].to_numpy(dtype=float)
+        * factor
+    )
+
+    out["rh_correction_factor"] = factor
+
+    # Uncapped scientific result used for validation and RMSE.
+    out["rh_corrected"] = corrected
+
+    # Capped version used only for optional display or QC.
+    out["rh_corrected_qc"] = np.clip(
+        corrected,
+        0.0,
+        cfg.max_corrected_rh,
+    )
+
+    return out
+# ============================================================
+# PREPARE INPUT DATA
+# ============================================================
+
+
+def _prepare_data(
+    frame: pd.DataFrame,
+    cfg: EnvelopeConfig,
+) -> pd.DataFrame:
+    """
+    Prepare valid subfreezing T/RH observations.
+    """
+
+    required = {
+        "T",
+        "rh",
+    }
+
+    missing = (
+        required
+        - set(frame.columns)
+    )
+
+    if missing:
+        raise KeyError(
+            "Envelope input is missing columns: "
+            f"{sorted(missing)}"
+        )
+
+    cold = frame[
+        [
+            "T",
+            "rh",
+        ]
+    ].copy()
+
+    # Convert to numeric
+    cold["T"] = pd.to_numeric(
+        cold["T"],
+        errors="coerce",
+    )
+
+    cold["rh"] = pd.to_numeric(
+        cold["rh"],
+        errors="coerce",
+    )
+
+    # Remove invalid values
+    cold = cold.replace(
+        [np.inf, -np.inf],
+        np.nan,
+    )
+
+    cold = cold.dropna(
+        subset=[
+            "T",
+            "rh",
+        ]
+    )
+
+    # Subfreezing data only
+    cold = cold[
+        (cold["T"] >= cfg.t_min)
+        &
+        (cold["T"] < cfg.t_max)
+    ]
+
+    # Remove gross RH outliers
+    cold = cold[
+        cold["rh"].between(
+            cfg.rh_min,
+            cfg.rh_max,
+        )
+    ]
+
+    cold = (
+        cold
+        .sort_values("T")
+        .reset_index(drop=True)
+    )
+
+    if cold.empty:
+        raise ValueError(
+            "No valid subfreezing RH observations "
+            "available for envelope fitting"
+        )
+
+    return cold
+
+
+# ============================================================
+# FIXED P95 TEMPERATURE BINS
+# ============================================================
+
+
+def _calculate_p95_bins(
+    cold: pd.DataFrame,
+    cfg: EnvelopeConfig,
+) -> pd.DataFrame:
+    """
+    Calculate fixed P95 in 2 deg C temperature bins.
+
+    Only bins containing at least 40 observations are accepted.
+    """
+
+    edges = np.arange(
+        cfg.t_min,
+        cfg.t_max
+        + cfg.bin_width,
+        cfg.bin_width,
+    )
+
+    working = cold.copy()
+
+    working["T_bin"] = pd.cut(
+        working["T"],
+        bins=edges,
+        include_lowest=True,
+    )
+
+    rows: list[dict] = []
+
+    for interval, group in working.groupby(
+        "T_bin",
+        observed=True,
+    ):
+
+        n = len(group)
+
+        # Minimum sample criterion
+        if n < cfg.min_points_per_bin:
+            continue
+
+        rh_values = group[
+            "rh"
+        ].to_numpy(
+            dtype=float
+        )
+
+        # ----------------------------------------------------
+        # P95 ONLY
+        # ----------------------------------------------------
+
+        p95 = float(
+            np.quantile(
+                rh_values,
+                0.95,
+            )
+        )
+
+        rows.append(
+            {
+                "T_mid": float(
+                    interval.mid
+                ),
+
+                "T_left": float(
+                    interval.left
+                ),
+
+                "T_right": float(
+                    interval.right
+                ),
+
+                "n": int(n),
+
+                "q_used": 0.95,
+
+                "p95": p95,
+
+                "selected": p95,
+
+                "point_type": "P95",
+            }
+        )
+
+    if len(rows) < 2:
+        raise ValueError(
+            "Too few populated temperature bins "
+            "for fixed-P95 envelope fitting"
+        )
+
+    result = pd.DataFrame(
+        rows
+    )
+
+    result = (
+        result
+        .sort_values("T_mid")
+        .reset_index(drop=True)
+    )
+
+    return result
+
+
+# ============================================================
+# COLD-TAIL SUPPORT
+# ============================================================
+
+
+def _cold_tail_support(
+    cold: pd.DataFrame,
+    p95_bins: pd.DataFrame,
+    cfg: EnvelopeConfig,
+) -> dict | None:
+    """
+    Construct one sparse observational support point when
+    observations extend colder than the first statistically
+    accepted P95 bin.
+
+    IMPORTANT
+    ---------
+    This point is not P95.
+
+    It is a support point based on real observations in a
+    temperature region where there are not enough observations
+    to estimate P95 reliably.
+
+    The point is NOT subsequently forced toward 100 %
+    saturation.
+    """
+
+    if p95_bins.empty:
+        return None
+
+    # Cold boundary of first accepted P95 bin
+    first_left = float(
+        p95_bins.iloc[0][
+            "T_left"
+        ]
+    )
+
+    # Select real observations colder than the first P95 bin
+    tail = cold[
+        cold["T"] < first_left
+    ].copy()
+
+    if len(tail) < cfg.cold_tail_min_points:
+        return None
+
+    # Coldest observations first
+    tail = tail.sort_values(
+        "T"
+    )
+
+    # Restrict support estimation to the coldest observations
+    tail = tail.head(
+        cfg.cold_tail_max_points
+    )
+
+    if len(tail) < cfg.cold_tail_min_points:
+        return None
+
+    temperatures = tail[
+        "T"
+    ].to_numpy(
+        dtype=float
+    )
+
+    rh_values = tail[
+        "rh"
+    ].to_numpy(
+        dtype=float
+    )
+
+    # Representative cold-tail temperature
+    support_temperature = float(
+        np.median(
+            temperatures
+        )
+    )
+
+    # Representative observational RH support
+    support_rh = float(
+        np.quantile(
+            rh_values,
+            cfg.cold_tail_quantile,
+        )
+    )
+
+    return {
+        "T_mid": support_temperature,
+
+        "T_left": float(
+            np.min(temperatures)
+        ),
+
+        "T_right": float(
+            np.max(temperatures)
+        ),
+
+        "n": int(
+            len(tail)
+        ),
+
+        "q_used": np.nan,
+
+        "p95": np.nan,
+
+        "selected": support_rh,
+
+        "point_type":
+            "cold_tail_support",
+    }
+
+
+# ============================================================
+# BUILD ENVELOPE SUPPORT
+# ============================================================
+
+
+def _build_support_table(
+    cold: pd.DataFrame,
+    p95_bins: pd.DataFrame,
+    cfg: EnvelopeConfig,
+) -> pd.DataFrame:
+    """
+    Build the support table containing:
+
+    - fixed P95 bins
+    - optional observational cold-tail support
+    """
+
+    support = p95_bins.copy()
+
+    tail = _cold_tail_support(
+        cold,
+        p95_bins,
+        cfg,
+    )
+
+    if tail is not None:
+
+        tail_frame = pd.DataFrame(
+            [tail]
+        )
+
+        support = pd.concat(
+            [
+                tail_frame,
+                support,
+            ],
+            ignore_index=True,
+        )
+
+    support = (
+        support
+        .sort_values("T_mid")
+        .drop_duplicates(
+            subset=[
+                "T_mid",
+            ],
+            keep="last",
+        )
+        .reset_index(drop=True)
+    )
+
+    return support
+
+
+# ============================================================
+# PCHIP INTERPOLATION
+# ============================================================
+
+
+def _fit_pchip(
+    support: pd.DataFrame,
+    cfg: EnvelopeConfig,
+) -> tuple[
+    np.ndarray,
+    np.ndarray,
+]:
+    """
+    Fit a shape-preserving PCHIP curve through the support
+    points.
+
+    Extrapolation beyond supported temperatures is disabled.
+
+    No post-PCHIP blending toward physical saturation is
+    applied. The cold end therefore remains controlled by the
+    observational cold-tail support point and the adjacent
+    fixed-P95 bins.
+    """
+
+    x = support[
+        "T_mid"
+    ].to_numpy(
+        dtype=float
+    )
+
+    y = support[
+        "selected"
+    ].to_numpy(
+        dtype=float
+    )
+
+    valid = (
+        np.isfinite(x)
+        &
+        np.isfinite(y)
+    )
+
+    x = x[
+        valid
+    ]
+
+    y = y[
+        valid
+    ]
+
+    if x.size < 2:
+        raise ValueError(
+            "At least two envelope support points "
+            "are required for PCHIP fitting"
+        )
+
+    # Sort by temperature
+    order = np.argsort(
+        x
+    )
+
+    x = x[
+        order
+    ]
+
+    y = y[
+        order
+    ]
+
+    # Remove duplicate temperatures
+    unique_x, indices = np.unique(
+        x,
+        return_index=True,
+    )
+
+    x = unique_x
+
+    y = y[
+        indices
+    ]
+
+    if x.size < 2:
+        raise ValueError(
+            "Envelope support temperatures "
+            "are not sufficiently distinct"
+        )
+
+    # Shape-preserving PCHIP
+    interpolator = PchipInterpolator(
+        x,
+        y,
+        extrapolate=False,
+    )
+
+    t_min_supported = float(
+        np.min(x)
+    )
+
+    t_max_supported = float(
+        np.max(x)
+    )
+
+    n_grid = max(
+        int(cfg.grid_points),
+        100,
+    )
+
+    grid_T = np.linspace(
+        t_min_supported,
+        t_max_supported,
+        n_grid,
+    )
+
+    envelope = interpolator(
+        grid_T
+    )
+
+    envelope = np.asarray(
+        envelope,
+        dtype=float,
+    )
+
+    # --------------------------------------------------------
+    # IMPORTANT:
+    #
+    # Do not blend the cold end toward 100 %.
+    #
+    # The cold end is already supported by real observations
+    # through _cold_tail_support(). PCHIP connects that support
+    # smoothly to the first statistically valid P95 bin.
+    # --------------------------------------------------------
+
+    return (
+        grid_T,
+        envelope,
+    )
+
+
+# ============================================================
+# CORRECTION FACTOR
+# ============================================================
+
+
+def _calculate_factor(
+    envelope: np.ndarray,
+    cfg: EnvelopeConfig,
+) -> np.ndarray:
+    """
+    Calculate the RH correction factor:
+
+        factor = physical_saturation / envelope
+    """
+
+    envelope = np.asarray(
+        envelope,
+        dtype=float,
+    )
+
+    safe = envelope.copy()
+
+    # Remove invalid envelope values
+    safe[
+        ~np.isfinite(safe)
+    ] = np.nan
+
+    safe[
+        safe <= 0
+    ] = np.nan
+
+    factor = (
+        cfg.physical_saturation
+        /
+        safe
+    )
+
+    # Keep correction bounded
+    factor = np.clip(
+        factor,
+        cfg.min_factor,
+        cfg.max_factor,
+    )
+
+    return factor
+
+
+# ============================================================
+# MAIN PUBLIC FUNCTION
+# ============================================================
+
+
+def fit_envelope(
+    frame: pd.DataFrame,
+    cfg: EnvelopeConfig,
+) -> EnvelopeResult:
+    """
+    Fit the fixed-P95 RH upper envelope.
+
+    Parameters
+    ----------
+    frame
+        DataFrame containing at least:
+
+            T
+            rh
+
+    cfg
+        EnvelopeConfig instance.
+
+    Returns
+    -------
+    EnvelopeResult
+        grid_T
+        envelope
+        factor
+        binned
+        diagnostics
+    """
+
+    # ========================================================
+    # FORCE THE FINAL METHOD
+    # ========================================================
+
+    cfg.bin_width = 2.0
+    cfg.percentile = 0.95
+    cfg.min_points_per_bin = 40
+
+    cfg.q_dense = 0.95
+    cfg.q_sparse = 0.95
+    cfg.sparse_threshold = 40
+
+    # ========================================================
+    # PREPARE VALID SUBFREEZING OBSERVATIONS
+    # ========================================================
+
+    cold = _prepare_data(
+        frame,
+        cfg,
+    )
+
+    # ========================================================
+    # CALCULATE TRUE P95 BINS
+    # ========================================================
+
+    p95_bins = _calculate_p95_bins(
+        cold,
+        cfg,
+    )
+
+    # ========================================================
+    # OPTIONAL OBSERVATIONAL COLD-TAIL SUPPORT
+    # ========================================================
+
+    support = _build_support_table(
+        cold,
+        p95_bins,
+        cfg,
+    )
+
+    # ========================================================
+    # FIT PCHIP ENVELOPE
+    # ========================================================
+
+    grid_T, envelope = _fit_pchip(
+        support,
+        cfg,
+    )
+
+    # ========================================================
+    # CALCULATE CORRECTION FACTOR
+    # ========================================================
+
+    factor = _calculate_factor(
+        envelope,
+        cfg,
+    )
+
+    # ========================================================
+    # DIAGNOSTICS
+    # ========================================================
+
+    p95_rows = support[
+        support["point_type"]
+        ==
+        "P95"
+    ]
+
+    tail_rows = support[
+        support["point_type"]
+        ==
+        "cold_tail_support"
+    ]
+
+    diagnostics = {
+        "method":
+            "fixed_P95",
+
+        "percentile":
+            0.95,
+
+        "bin_width_degC":
+            2.0,
+
+        "min_points_per_bin":
+            40,
+
+        "n_input_subfreezing":
+            int(
+                len(cold)
+            ),
+
+        "n_p95_bins":
+            int(
+                len(p95_rows)
+            ),
+
+        "cold_tail_used":
+            bool(
+                not tail_rows.empty
+            ),
+
+        "observed_temperature_min":
+            float(
+                cold["T"].min()
+            ),
+
+        "observed_temperature_max":
+            float(
+                cold["T"].max()
+            ),
+
+        "support_temperature_min":
+            float(
+                support["T_mid"].min()
+            ),
+
+        "support_temperature_max":
+            float(
+                support["T_mid"].max()
+            ),
+
+        "factor_min":
+            float(
+                np.nanmin(factor)
+            ),
+
+        "factor_max":
+            float(
+                np.nanmax(factor)
+            ),
+    }
+
+    # --------------------------------------------------------
+    # Cold-tail diagnostics when used
+    # --------------------------------------------------------
+
+    if not tail_rows.empty:
+
+        tail_row = tail_rows.iloc[
+            0
+        ]
+
+        diagnostics[
+            "cold_tail_temperature"
+        ] = float(
+            tail_row[
+                "T_mid"
+            ]
+        )
+
+        diagnostics[
+            "cold_tail_rh"
+        ] = float(
+            tail_row[
+                "selected"
+            ]
+        )
+
+        diagnostics[
+            "cold_tail_n"
+        ] = int(
+            tail_row[
+                "n"
+            ]
+        )
+
+    # ========================================================
+    # RETURN
+    # ========================================================
+
+    return EnvelopeResult(
+        grid_T=grid_T,
+        envelope=envelope,
+        factor=factor,
+        binned=support,
+        diagnostics=diagnostics,
+    )

--- a/tests/unit/variables/test_humidity_recalibration.py
+++ b/tests/unit/variables/test_humidity_recalibration.py
@@ -1,0 +1,457 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from pypromice.core.variables.humidity_recalibration import (
+    EnvelopeConfig,
+    EnvelopeResult,
+    apply_correction,
+    fit_envelope,
+)
+
+
+def make_two_bin_frame():
+    """
+    Deterministic input containing two statistically valid
+    2 deg C temperature bins with 40 observations each.
+    """
+
+    t_bin_1 = np.full(40, -5.0)
+    t_bin_2 = np.full(40, -3.0)
+
+    rh_bin_1 = np.linspace(80.0, 100.0, 40)
+    rh_bin_2 = np.linspace(85.0, 105.0, 40)
+
+    return pd.DataFrame(
+        {
+            "T": np.concatenate(
+                [
+                    t_bin_1,
+                    t_bin_2,
+                ]
+            ),
+            "rh": np.concatenate(
+                [
+                    rh_bin_1,
+                    rh_bin_2,
+                ]
+            ),
+        }
+    )
+
+
+def test_fixed_p95_bins():
+    """
+    Valid bins must use fixed P95 with at least 40 observations.
+    """
+
+    frame = make_two_bin_frame()
+    cfg = EnvelopeConfig()
+
+    result = fit_envelope(
+        frame,
+        cfg,
+    )
+
+    p95_rows = result.binned[
+        result.binned["point_type"] == "P95"
+    ]
+
+    assert len(p95_rows) == 2
+
+    assert np.all(
+        p95_rows["n"].to_numpy()
+        == 40
+    )
+
+    assert np.allclose(
+        p95_rows["q_used"].to_numpy(dtype=float),
+        0.95,
+    )
+
+    assert np.allclose(
+        p95_rows["selected"].to_numpy(dtype=float),
+        p95_rows["p95"].to_numpy(dtype=float),
+    )
+
+
+def test_bins_below_minimum_count_are_rejected():
+    """
+    Fewer than 40 observations per bin must not produce
+    a statistically valid P95 envelope.
+    """
+
+    frame = pd.DataFrame(
+        {
+            "T": np.concatenate(
+                [
+                    np.full(39, -5.0),
+                    np.full(39, -3.0),
+                ]
+            ),
+            "rh": np.concatenate(
+                [
+                    np.linspace(80.0, 100.0, 39),
+                    np.linspace(85.0, 105.0, 39),
+                ]
+            ),
+        }
+    )
+
+    cfg = EnvelopeConfig()
+
+    with pytest.raises(
+        ValueError,
+        match="Too few populated temperature bins",
+    ):
+        fit_envelope(
+            frame,
+            cfg,
+        )
+
+
+def test_cold_tail_support_is_observational_not_p95():
+    """
+    Sparse cold observations should create an observational
+    support point and must not be labelled P95.
+    """
+
+    base = make_two_bin_frame()
+
+    cold_tail = pd.DataFrame(
+        {
+            "T": np.linspace(
+                -20.0,
+                -10.0,
+                10,
+            ),
+            "rh": np.linspace(
+                70.0,
+                79.0,
+                10,
+            ),
+        }
+    )
+
+    frame = pd.concat(
+        [
+            cold_tail,
+            base,
+        ],
+        ignore_index=True,
+    )
+
+    cfg = EnvelopeConfig()
+
+    result = fit_envelope(
+        frame,
+        cfg,
+    )
+
+    tail = result.binned[
+        result.binned["point_type"]
+        == "cold_tail_support"
+    ]
+
+    assert len(tail) == 1
+
+    row = tail.iloc[0]
+
+    assert np.isnan(
+        float(row["q_used"])
+    )
+
+    assert np.isnan(
+        float(row["p95"])
+    )
+
+    assert np.isfinite(
+        float(row["selected"])
+    )
+
+    assert result.diagnostics[
+        "cold_tail_used"
+    ] is True
+
+
+def test_no_cold_tail_when_too_few_observations():
+    """
+    Fewer than cold_tail_min_points observations must not
+    create a cold-tail support point.
+    """
+
+    base = make_two_bin_frame()
+
+    cold_tail = pd.DataFrame(
+        {
+            "T": np.linspace(
+                -20.0,
+                -10.0,
+                7,
+            ),
+            "rh": np.linspace(
+                70.0,
+                76.0,
+                7,
+            ),
+        }
+    )
+
+    frame = pd.concat(
+        [
+            cold_tail,
+            base,
+        ],
+        ignore_index=True,
+    )
+
+    cfg = EnvelopeConfig()
+
+    result = fit_envelope(
+        frame,
+        cfg,
+    )
+
+    assert (
+        result.binned["point_type"]
+        == "cold_tail_support"
+    ).sum() == 0
+
+    assert result.diagnostics[
+        "cold_tail_used"
+    ] is False
+
+
+def test_factor_matches_physical_saturation_over_envelope():
+    """
+    The correction factor must equal 100 / fitted envelope
+    wherever the raw value lies inside the configured bounds.
+    """
+
+    frame = make_two_bin_frame()
+    cfg = EnvelopeConfig()
+
+    result = fit_envelope(
+        frame,
+        cfg,
+    )
+
+    expected = (
+        cfg.physical_saturation
+        / result.envelope
+    )
+
+    expected = np.clip(
+        expected,
+        cfg.min_factor,
+        cfg.max_factor,
+    )
+
+    assert np.allclose(
+        result.factor,
+        expected,
+    )
+
+
+def test_factor_stays_within_configured_bounds():
+    """
+    Every fitted correction factor must respect the configured
+    minimum and maximum factor limits.
+    """
+
+    frame = make_two_bin_frame()
+    cfg = EnvelopeConfig()
+
+    result = fit_envelope(
+        frame,
+        cfg,
+    )
+
+    assert np.nanmin(
+        result.factor
+    ) >= cfg.min_factor
+
+    assert np.nanmax(
+        result.factor
+    ) <= cfg.max_factor
+
+
+def test_factor_at_temperature_boundaries():
+    """
+    Colder temperatures use the coldest fitted factor.
+    Warmer temperatures receive no correction.
+    """
+
+    envelope = EnvelopeResult(
+        grid_T=np.array(
+            [
+                -20.0,
+                -10.0,
+            ]
+        ),
+        envelope=np.array(
+            [
+                80.0,
+                100.0,
+            ]
+        ),
+        factor=np.array(
+            [
+                1.25,
+                1.0,
+            ]
+        ),
+        binned=pd.DataFrame(),
+    )
+
+    values = envelope.factor_at(
+        np.array(
+            [
+                -30.0,
+                -15.0,
+                5.0,
+            ]
+        )
+    )
+
+    assert values[0] == pytest.approx(
+        1.25
+    )
+
+    assert values[1] == pytest.approx(
+        1.125
+    )
+
+    assert values[2] == pytest.approx(
+        1.0
+    )
+
+
+def test_apply_correction_keeps_scientific_result_uncapped():
+    """
+    Scientific RH remains uncapped while the separate QC
+    variable is capped at max_corrected_rh.
+    """
+
+    envelope = EnvelopeResult(
+        grid_T=np.array(
+            [
+                -20.0,
+                -10.0,
+            ]
+        ),
+        envelope=np.array(
+            [
+                80.0,
+                80.0,
+            ]
+        ),
+        factor=np.array(
+            [
+                1.25,
+                1.25,
+            ]
+        ),
+        binned=pd.DataFrame(),
+    )
+
+    frame = pd.DataFrame(
+        {
+            "T": [
+                -15.0,
+            ],
+            "rh": [
+                90.0,
+            ],
+        }
+    )
+
+    cfg = EnvelopeConfig()
+
+    corrected = apply_correction(
+        frame,
+        envelope,
+        cfg,
+    )
+
+    assert corrected.loc[
+        0,
+        "rh_correction_factor",
+    ] == pytest.approx(
+        1.25
+    )
+
+    assert corrected.loc[
+        0,
+        "rh_corrected",
+    ] == pytest.approx(
+        112.5
+    )
+
+    assert corrected.loc[
+        0,
+        "rh_corrected_qc",
+    ] == pytest.approx(
+        100.0
+    )
+
+
+def test_invalid_input_columns_raise_key_error():
+    """
+    Envelope input must contain both T and rh.
+    """
+
+    frame = pd.DataFrame(
+        {
+            "temperature": [
+                -10.0,
+            ],
+            "humidity": [
+                90.0,
+            ],
+        }
+    )
+
+    cfg = EnvelopeConfig()
+
+    with pytest.raises(
+        KeyError,
+        match="Envelope input is missing columns",
+    ):
+        fit_envelope(
+            frame,
+            cfg,
+        )
+
+
+def test_no_valid_subfreezing_data_raises_value_error():
+    """
+    A dataset containing no valid subfreezing observations
+    cannot be used for envelope fitting.
+    """
+
+    frame = pd.DataFrame(
+        {
+            "T": [
+                1.0,
+                5.0,
+                10.0,
+            ],
+            "rh": [
+                80.0,
+                90.0,
+                100.0,
+            ],
+        }
+    )
+
+    cfg = EnvelopeConfig()
+
+    with pytest.raises(
+        ValueError,
+        match="No valid subfreezing RH observations",
+    ):
+        fit_envelope(
+            frame,
+            cfg,
+        )


### PR DESCRIPTION
## Summary

Adds a temperature-dependent relative humidity recalibration method for PROMICE/GC-Net AWS data.

The implementation estimates the sub-freezing RH upper envelope using fixed temperature bins and P95 statistics, with optional observational support in the sparse cold tail. A PCHIP fit is used to represent the supported envelope and derive a bounded multiplicative correction factor.

## Method

The implementation:

- uses observations below 0 °C
- uses fixed 2 °C temperature bins
- requires at least 40 observations for a statistical bin
- uses P95 as the upper-envelope statistic
- supports the sparse cold tail using observational data when available
- does not artificially blend the cold tail towards saturation
- uses PCHIP interpolation for the supported envelope
- derives a bounded multiplicative RH correction factor

## Files added

- `src/pypromice/core/variables/humidity_recalibration.py`
- `tests/unit/variables/test_humidity_recalibration.py`

## Testing

Dedicated humidity recalibration unit tests were run locally with Python 3.12.10 on Windows:

`10 passed`

The dedicated tests cover:

- fixed P95 temperature bins
- rejection of bins below the minimum observation count
- observational cold-tail support
- insufficient cold-tail observations
- physical saturation/envelope correction-factor behaviour
- correction-factor bounds
- temperature-boundary behaviour
- uncapped scientific corrected RH values
- invalid input columns
- absence of valid sub-freezing observations

The broader pypromice test suite has additional failures in unrelated modules in my local Windows environment, including Windows temporary-file/file-locking, BUFR, ingest, E2E and transmission tests. The dedicated humidity recalibration tests pass.